### PR TITLE
Fix Minecraft plugin matching and version picker

### DIFF
--- a/apps/dashboard/app/components/gameserver/MinecraftModsBrowser.vue
+++ b/apps/dashboard/app/components/gameserver/MinecraftModsBrowser.vue
@@ -603,12 +603,30 @@
           <OuiSelect
             v-model="selectedVersionId"
             :disabled="isVersionsLoading || versionOptions.length === 0"
-            :items="versionOptions.map(v => ({
-              label: `${v.versionNumber} • ${v.gameVersions?.join(', ') || 'Any version'}`,
-              value: v.id,
-            }))"
+            :items="versionSelectItems"
             placeholder="Select a version"
           />
+          <OuiStack
+            v-if="selectedVersion"
+            gap="xs"
+            class="rounded-lg border border-border-muted bg-surface-muted/20 px-3 py-2"
+          >
+            <OuiFlex wrap="wrap" gap="xs" align="center">
+              <OuiBadge size="xs" variant="secondary">{{ selectedVersion.versionNumber }}</OuiBadge>
+              <OuiBadge
+                v-for="loader in selectedVersion.loaders"
+                :key="`selected-version-loader-${loader}`"
+                size="xs"
+                variant="secondary"
+                tone="soft"
+              >
+                {{ loader }}
+              </OuiBadge>
+            </OuiFlex>
+            <OuiText size="xs" color="tertiary" class="leading-relaxed break-words">
+              Supports {{ formatVersionSupport(selectedVersion.gameVersions) }}
+            </OuiText>
+          </OuiStack>
           <OuiText v-if="isVersionsLoading" size="xs" color="tertiary">
             Loading versions…
           </OuiText>
@@ -912,6 +930,15 @@ const installDialogTitle = computed(() =>
 const installLocationDescription = computed(() => {
   return projectType.value === MinecraftProjectType.PLUGIN ? "plugins directory" : "mods directory";
 });
+const selectedVersion = computed(() => {
+  return versionOptions.value.find((version) => version.id === selectedVersionId.value) || null;
+});
+const versionSelectItems = computed(() =>
+  versionOptions.value.map((version) => ({
+    label: formatVersionOptionLabel(version),
+    value: version.id,
+  }))
+);
 
 const debouncedSearch = useDebounceFn(() => refresh(), 350);
 const { stop: stopAutoLoadObserver } = useIntersectionObserver(
@@ -1227,6 +1254,44 @@ function formatBytes(bytes?: bigint | number | null) {
   if (value >= 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(1)} MB`;
   if (value >= 1024) return `${(value / 1024).toFixed(1)} KB`;
   return `${value} B`;
+}
+
+function formatVersionOptionLabel(version: MinecraftProjectVersion) {
+  const parts = [version.versionNumber || version.name || "Unnamed version"];
+  const support = summarizeVersionSupport(version.gameVersions);
+  if (support) {
+    parts.push(support);
+  }
+  if (version.loaders?.length) {
+    parts.push(version.loaders.slice(0, 3).join(", "));
+  }
+  return parts.join(" - ");
+}
+
+function summarizeVersionSupport(versions?: string[] | null) {
+  const normalized = normalizeMinecraftVersions(versions);
+  if (normalized.length === 0) return "Any Minecraft version";
+  if (normalized.length === 1) return normalized[0];
+  if (normalized.length <= 3) return normalized.join(", ");
+  return `${normalized[0]}-${normalized[normalized.length - 1]}`;
+}
+
+function formatVersionSupport(versions?: string[] | null) {
+  const normalized = normalizeMinecraftVersions(versions);
+  if (normalized.length === 0) return "any Minecraft version";
+  if (normalized.length <= 12) return normalized.join(", ");
+  return `${normalized.slice(0, 8).join(", ")} and ${normalized.length - 8} more through ${normalized[normalized.length - 1]}`;
+}
+
+function normalizeMinecraftVersions(versions?: string[] | null) {
+  const unique = Array.from(
+    new Set(
+      (versions || [])
+        .map((version) => version.replace(/^v/i, "").trim())
+        .filter(Boolean)
+    )
+  );
+  return unique.sort((a, b) => compareVersions(a, b));
 }
 
 function parseVersion(version: string): number[] {

--- a/apps/dashboard/app/components/oui/Select.vue
+++ b/apps/dashboard/app/components/oui/Select.vue
@@ -41,13 +41,13 @@
               class="z-50 min-w-[12rem] max-h-[300px] w-[--reference-width] overflow-y-auto rounded-xl border border-border-default bg-surface-base shadow-md animate-in data-[side=bottom]:slide-in-from-top-2"
             >
               <Select.ItemGroup>
-                <Select.Item
-                  v-for="item in collection.items"
-                  :key="item.value"
-                  :item="item"
-                  class="relative text-primary flex w-full cursor-pointer select-none items-center justify-between gap-2 py-2 px-4 text-sm transition-colors duration-150 hover:bg-surface-raised data-disabled:cursor-not-allowed data-disabled:text-text-muted data-disabled:opacity-60"
-                >
-                  <Select.ItemText>{{ item.label }}</Select.ItemText>
+                  <Select.Item
+                    v-for="item in collection.items"
+                    :key="item.value"
+                    :item="item"
+                    class="relative text-primary flex w-full min-w-0 cursor-pointer select-none items-center justify-between gap-2 py-2 px-4 text-sm transition-colors duration-150 hover:bg-surface-raised data-disabled:cursor-not-allowed data-disabled:text-text-muted data-disabled:opacity-60"
+                  >
+                    <Select.ItemText class="min-w-0 truncate">{{ item.label }}</Select.ItemText>
 
                   <Select.ItemIndicator>
                     <CheckIcon class="h-4 w-4 text-primary" />
@@ -65,13 +65,13 @@
             class="z-50 min-w-[12rem] max-h-[300px] w-[--reference-width] overflow-y-auto rounded-xl border border-border-default bg-surface-base shadow-md hidden"
           >
             <Select.ItemGroup>
-              <Select.Item
-                v-for="item in collection.items"
-                :key="item.value"
-                :item="item"
-                class="relative text-primary flex w-full cursor-pointer select-none items-center justify-between gap-2 py-2 px-4 text-sm transition-colors duration-150 hover:bg-surface-raised data-disabled:cursor-not-allowed data-disabled:text-text-muted data-disabled:opacity-60"
-              >
-                <Select.ItemText>{{ item.label }}</Select.ItemText>
+                <Select.Item
+                  v-for="item in collection.items"
+                  :key="item.value"
+                  :item="item"
+                  class="relative text-primary flex w-full min-w-0 cursor-pointer select-none items-center justify-between gap-2 py-2 px-4 text-sm transition-colors duration-150 hover:bg-surface-raised data-disabled:cursor-not-allowed data-disabled:text-text-muted data-disabled:opacity-60"
+                >
+                  <Select.ItemText class="min-w-0 truncate">{{ item.label }}</Select.ItemText>
 
                 <Select.ItemIndicator>
                   <CheckIcon class="h-4 w-4 text-primary" />

--- a/apps/gameservers-service/internal/catalog/modrinth/client.go
+++ b/apps/gameservers-service/internal/catalog/modrinth/client.go
@@ -3,6 +3,7 @@ package modrinth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,8 @@ const (
 	defaultUA      = "obiente-cloud-gameservers-service"
 	maxLimit       = 100
 )
+
+var ErrNotFound = errors.New("modrinth resource not found")
 
 // Client wraps the Modrinth REST API.
 type Client struct {
@@ -287,6 +290,49 @@ func (c *Client) GetVersion(ctx context.Context, versionID string) (*Version, er
 	return &version, nil
 }
 
+// GetVersionByFileHash returns the Modrinth version that owns a file hash.
+func (c *Client) GetVersionByFileHash(ctx context.Context, fileHash, algorithm string) (*Version, error) {
+	fileHash = strings.TrimSpace(fileHash)
+	if fileHash == "" {
+		return nil, fmt.Errorf("file hash is required")
+	}
+	algorithm = strings.TrimSpace(strings.ToLower(algorithm))
+	if algorithm == "" {
+		algorithm = "sha1"
+	}
+
+	values := url.Values{}
+	values.Set("algorithm", algorithm)
+	endpoint := fmt.Sprintf("%s/version_file/%s?%s", c.baseURL, url.PathEscape(fileHash), values.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+		return nil, fmt.Errorf("modrinth version file lookup failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload versionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode version file lookup: %w", err)
+	}
+
+	version := mapVersion(payload)
+	return &version, nil
+}
+
 // --- internal helpers ---
 
 type searchResponse struct {
@@ -332,24 +378,24 @@ type versionResponse struct {
 }
 
 type projectDetailResponse struct {
-	ID            string              `json:"id"`
-	Slug          string              `json:"slug"`
-	Title         string              `json:"title"`
-	Description   string              `json:"description"`
-	Body          string              `json:"body"`
-	ProjectType   string              `json:"project_type"`
-	IconURL       string              `json:"icon_url"`
-	Categories    []string            `json:"categories"`
-	Loaders       []string            `json:"loaders"`
-	GameVersions  []string            `json:"game_versions"`
-	Team          json.RawMessage     `json:"team"` // Can be array or string, handle dynamically
-	Downloads     int64               `json:"downloads"`
-	Rating        float64             `json:"rating"`
-	LatestVersion string              `json:"latest_version"`
-	ProjectURL    string              `json:"project_url"`
-	SourceURL     string              `json:"source_url"`
-	IssuesURL     string              `json:"issues_url"`
-	Gallery       json.RawMessage     `json:"gallery"` // Can be array of strings or objects, handle dynamically
+	ID            string          `json:"id"`
+	Slug          string          `json:"slug"`
+	Title         string          `json:"title"`
+	Description   string          `json:"description"`
+	Body          string          `json:"body"`
+	ProjectType   string          `json:"project_type"`
+	IconURL       string          `json:"icon_url"`
+	Categories    []string        `json:"categories"`
+	Loaders       []string        `json:"loaders"`
+	GameVersions  []string        `json:"game_versions"`
+	Team          json.RawMessage `json:"team"` // Can be array or string, handle dynamically
+	Downloads     int64           `json:"downloads"`
+	Rating        float64         `json:"rating"`
+	LatestVersion string          `json:"latest_version"`
+	ProjectURL    string          `json:"project_url"`
+	SourceURL     string          `json:"source_url"`
+	IssuesURL     string          `json:"issues_url"`
+	Gallery       json.RawMessage `json:"gallery"` // Can be array of strings or objects, handle dynamically
 }
 
 type galleryItem struct {

--- a/apps/gameservers-service/internal/catalog/modrinth/client_test.go
+++ b/apps/gameservers-service/internal/catalog/modrinth/client_test.go
@@ -1,0 +1,61 @@
+package modrinth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetVersionByFileHash(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/version_file/abc123" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("algorithm"); got != "sha1" {
+			t.Fatalf("expected sha1 algorithm, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"version-id",
+			"project_id":"project-id",
+			"name":"Release",
+			"version_number":"1.0.0",
+			"game_versions":["1.20.1"],
+			"loaders":["paper"],
+			"server_side":"required",
+			"client_side":"unsupported",
+			"date_published":"2024-01-02T03:04:05Z",
+			"files":[{"hashes":{"sha1":"abc123"},"primary":true,"filename":"Plugin.jar","url":"https://example.test/plugin.jar","size":123}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client())
+	client.baseURL = server.URL
+
+	version, err := client.GetVersionByFileHash(context.Background(), "abc123", "sha1")
+	if err != nil {
+		t.Fatalf("GetVersionByFileHash returned error: %v", err)
+	}
+	if version.ID != "version-id" || version.ProjectID != "project-id" {
+		t.Fatalf("unexpected version: %#v", version)
+	}
+	if len(version.Files) != 1 || version.Files[0].Filename != "Plugin.jar" {
+		t.Fatalf("unexpected files: %#v", version.Files)
+	}
+}
+
+func TestGetVersionByFileHashNotFound(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	client := NewClient(server.Client())
+	client.baseURL = server.URL
+
+	_, err := client.GetVersionByFileHash(context.Background(), "missing", "sha1")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/apps/gameservers-service/internal/service/minecraft_catalog.go
+++ b/apps/gameservers-service/internal/service/minecraft_catalog.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -195,6 +196,7 @@ func (s *Service) ListInstalledMinecraftProjects(ctx context.Context, req *conne
 
 	serverVersion := minecraftServerVersion(dbGameServer.ServerVersion, env)
 	files := make([]*gameserversv1.InstalledMinecraftProjectFile, 0, len(entries))
+	metadataDirty := false
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".jar") {
 			continue
@@ -207,6 +209,15 @@ func (s *Service) ListInstalledMinecraftProjects(ctx context.Context, req *conne
 		}
 
 		meta, managed := metadata.Files[entry.Name()]
+		if req.Msg.GetCheckUpdates() && !managed {
+			discoveredMeta, ok := s.discoverMinecraftInstallMetadata(ctx, installDir, profile.InstallDir, entry.Name(), projectType)
+			if ok {
+				meta = discoveredMeta
+				managed = true
+				metadata.Files[entry.Name()] = discoveredMeta
+				metadataDirty = true
+			}
+		}
 		file := installedFileToProto(profile.InstallDir, entry.Name(), info, projectType, meta, managed)
 		if req.Msg.GetCheckUpdates() && managed && meta.ProjectID != "" && meta.VersionID != "" {
 			if latest := s.latestCompatibleVersion(ctx, meta.ProjectID, serverType, projectType, serverVersion); latest != nil && latest.ID != meta.VersionID {
@@ -217,6 +228,11 @@ func (s *Service) ListInstalledMinecraftProjects(ctx context.Context, req *conne
 			}
 		}
 		files = append(files, file)
+	}
+	if metadataDirty {
+		if err := saveMinecraftInstallMetadata(installDir, metadata); err != nil {
+			logger.Warn("[MinecraftCatalog] Failed to persist discovered install metadata for %s: %v", dbGameServer.ID, err)
+		}
 	}
 
 	return connect.NewResponse(&gameserversv1.ListInstalledMinecraftProjectsResponse{
@@ -669,6 +685,78 @@ func (s *Service) upsertMinecraftInstallMetadata(installDir, filename, installed
 	return saveMinecraftInstallMetadata(installDir, metadata)
 }
 
+func (s *Service) discoverMinecraftInstallMetadata(ctx context.Context, installDir, installRelDir, filename string, projectType gameserversv1.MinecraftProjectType) (minecraftInstallMetadataEntry, bool) {
+	absPath := filepath.Join(installDir, filename)
+	sha1sum, err := fileHash(absPath, sha1.New())
+	if err != nil {
+		logger.Warn("[MinecraftCatalog] Failed to hash installed file %s: %v", filename, err)
+		return minecraftInstallMetadataEntry{}, false
+	}
+
+	version, err := s.modClient.GetVersionByFileHash(ctx, sha1sum, "sha1")
+	if err != nil {
+		if !errors.Is(err, modrinth.ErrNotFound) {
+			logger.Warn("[MinecraftCatalog] Failed to identify installed file %s by hash: %v", filename, err)
+		}
+		return minecraftInstallMetadataEntry{}, false
+	}
+	if version == nil || version.ProjectID == "" || version.ID == "" {
+		return minecraftInstallMetadataEntry{}, false
+	}
+
+	var project *modrinth.Project
+	if fetched, err := s.modClient.GetProject(ctx, version.ProjectID); err == nil {
+		project = fetched
+		if modrinthTypeToProto(project.ProjectType) != projectType {
+			return minecraftInstallMetadataEntry{}, false
+		}
+	} else {
+		logger.Warn("[MinecraftCatalog] Failed to fetch project metadata for discovered file %s: %v", filename, err)
+	}
+
+	file := matchingVersionFile(version.Files, sha1sum, "sha1", filename)
+	hashes := map[string]string{"sha1": sha1sum}
+	size := int64(0)
+	if file != nil {
+		size = file.Size
+		if len(file.Hashes) > 0 {
+			hashes = file.Hashes
+		}
+	}
+	info, err := os.Stat(absPath)
+	if err == nil && size == 0 {
+		size = info.Size()
+	}
+
+	title := filename
+	slug := ""
+	iconURL := ""
+	if project != nil {
+		title = firstNonEmpty(project.Title, filename)
+		slug = project.Slug
+		iconURL = project.IconURL
+	}
+
+	entry := minecraftInstallMetadataEntry{
+		ProjectID:     version.ProjectID,
+		ProjectSlug:   slug,
+		Title:         title,
+		IconURL:       iconURL,
+		ProjectType:   projectType,
+		VersionID:     version.ID,
+		VersionNumber: version.VersionNumber,
+		GameVersions:  version.GameVersions,
+		Loaders:       version.Loaders,
+		Filename:      filename,
+		InstalledPath: filepath.Join(installRelDir, filename),
+		SizeBytes:     size,
+		Hashes:        hashes,
+		InstalledAt:   time.Now().UTC(),
+	}
+	logger.Info("[MinecraftCatalog] Matched existing installed file %s to Modrinth project %s version %s", filename, entry.ProjectID, entry.VersionID)
+	return entry, true
+}
+
 func installedFileToProto(installRelDir, filename string, info os.FileInfo, projectType gameserversv1.MinecraftProjectType, meta minecraftInstallMetadataEntry, managed bool) *gameserversv1.InstalledMinecraftProjectFile {
 	relPath := filepath.Join(installRelDir, filename)
 	modifiedAt := timestamppb.New(info.ModTime())
@@ -698,6 +786,20 @@ func installedFileToProto(installRelDir, filename string, info os.FileInfo, proj
 		}
 	}
 	return file
+}
+
+func matchingVersionFile(files []modrinth.VersionFile, expectedHash, algorithm, filename string) *modrinth.VersionFile {
+	for i := range files {
+		if strings.EqualFold(files[i].Hashes[algorithm], expectedHash) {
+			return &files[i]
+		}
+	}
+	for i := range files {
+		if strings.EqualFold(files[i].Filename, filename) {
+			return &files[i]
+		}
+	}
+	return selectDownloadFile(files)
 }
 
 func (s *Service) latestCompatibleVersion(ctx context.Context, projectID, serverType string, projectType gameserversv1.MinecraftProjectType, serverVersion string) *modrinth.Version {
@@ -1107,6 +1209,19 @@ func downloadAndVerify(ctx context.Context, url string, dest string, hashes map[
 	}
 
 	return os.Chmod(dest, 0o644)
+}
+
+func fileHash(path string, hasher hash.Hash) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }
 
 func verifyHash(name string, hasher hash.Hash, expected string) error {

--- a/apps/gameservers-service/internal/service/minecraft_catalog_test.go
+++ b/apps/gameservers-service/internal/service/minecraft_catalog_test.go
@@ -1,0 +1,44 @@
+package gameservers
+
+import (
+	"crypto/sha1"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gameservers-service/internal/catalog/modrinth"
+)
+
+func TestMatchingVersionFilePrefersHash(t *testing.T) {
+	files := []modrinth.VersionFile{
+		{
+			Filename: "Plugin.jar",
+			Hashes:   map[string]string{"sha1": "old"},
+		},
+		{
+			Filename: "Plugin-Renamed.jar",
+			Hashes:   map[string]string{"sha1": "expected"},
+		},
+	}
+
+	file := matchingVersionFile(files, "expected", "sha1", "Plugin.jar")
+	if file == nil || file.Filename != "Plugin-Renamed.jar" {
+		t.Fatalf("expected hash match, got %#v", file)
+	}
+}
+
+func TestFileHash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.jar")
+	if err := os.WriteFile(path, []byte("plugin-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum, err := fileHash(path, sha1.New())
+	if err != nil {
+		t.Fatalf("fileHash returned error: %v", err)
+	}
+	if sum != "d093414c4a97fac29482fb0dfb22872a2d8ddd90" {
+		t.Fatalf("unexpected hash %s", sum)
+	}
+}


### PR DESCRIPTION
## Summary
- identify existing Minecraft jars through Modrinth file-hash lookup so known plugins can become managed/updateable
- persist recovered install metadata after a match so future refreshes are cheap
- compact install version dropdown labels and show detailed version support below the selector

## Verification
- go test ./internal/catalog/modrinth ./internal/service
- pnpm --dir apps/dashboard exec vue-tsc --noEmit --project tsconfig.json
- pnpm --dir apps/dashboard typecheck