### PR TITLE
Make Minecraft plugin updates safer

### DIFF
--- a/apps/gameservers-service/internal/catalog/modrinth/client.go
+++ b/apps/gameservers-service/internal/catalog/modrinth/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -16,9 +17,25 @@ const (
 	defaultBaseURL = "https://api.modrinth.com/v2"
 	defaultUA      = "obiente-cloud-gameservers-service"
 	maxLimit       = 100
+	maxAttempts    = 3
 )
 
 var ErrNotFound = errors.New("modrinth resource not found")
+
+// RateLimitError indicates Modrinth asked the client to slow down.
+type RateLimitError struct {
+	Operation  string
+	StatusCode int
+	RetryAfter time.Duration
+	Body       string
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("%s rate limited: retry after %s", e.Operation, e.RetryAfter.Round(time.Second))
+	}
+	return fmt.Sprintf("%s rate limited", e.Operation)
+}
 
 // Client wraps the Modrinth REST API.
 type Client struct {
@@ -141,26 +158,13 @@ func (c *Client) SearchProjects(ctx context.Context, params SearchParams) (*Sear
 	}
 	values.Set("index", "relevance")
 
-	endpoint := fmt.Sprintf("%s/search?%s", c.baseURL, values.Encode())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	body, err := c.get(ctx, fmt.Sprintf("%s/search?%s", c.baseURL, values.Encode()), "modrinth search")
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
-		return nil, fmt.Errorf("modrinth search failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var payload searchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode search response: %w", err)
 	}
 
@@ -179,26 +183,9 @@ func (c *Client) SearchProjects(ctx context.Context, params SearchParams) (*Sear
 
 // GetProject returns full project details including body and gallery.
 func (c *Client) GetProject(ctx context.Context, projectID string) (*Project, error) {
-	endpoint := fmt.Sprintf("%s/project/%s", c.baseURL, projectID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	body, err := c.get(ctx, fmt.Sprintf("%s/project/%s", c.baseURL, projectID), "modrinth project")
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
 	}
 
 	var payload projectDetailResponse
@@ -231,26 +218,13 @@ func (c *Client) GetProjectVersions(ctx context.Context, projectID string, filte
 		}
 	}
 
-	endpoint := fmt.Sprintf("%s/project/%s/version?%s", c.baseURL, projectID, values.Encode())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	body, err := c.get(ctx, fmt.Sprintf("%s/project/%s/version?%s", c.baseURL, projectID, values.Encode()), "modrinth versions")
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
-		return nil, fmt.Errorf("modrinth versions failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var payload []versionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode versions: %w", err)
 	}
 
@@ -264,26 +238,13 @@ func (c *Client) GetProjectVersions(ctx context.Context, projectID string, filte
 
 // GetVersion fetches a single version by ID.
 func (c *Client) GetVersion(ctx context.Context, versionID string) (*Version, error) {
-	endpoint := fmt.Sprintf("%s/version/%s", c.baseURL, versionID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	body, err := c.get(ctx, fmt.Sprintf("%s/version/%s", c.baseURL, versionID), "modrinth version")
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
-		return nil, fmt.Errorf("modrinth version failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var payload versionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode version: %w", err)
 	}
 
@@ -304,29 +265,17 @@ func (c *Client) GetVersionByFileHash(ctx context.Context, fileHash, algorithm s
 
 	values := url.Values{}
 	values.Set("algorithm", algorithm)
-	endpoint := fmt.Sprintf("%s/version_file/%s?%s", c.baseURL, url.PathEscape(fileHash), values.Encode())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	body, err := c.get(ctx, fmt.Sprintf("%s/version_file/%s?%s", c.baseURL, url.PathEscape(fileHash), values.Encode()), "modrinth version file lookup")
 	if err != nil {
+		var httpErr *httpError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, ErrNotFound
+		}
 		return nil, err
-	}
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
-		return nil, fmt.Errorf("modrinth version file lookup failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var payload versionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("decode version file lookup: %w", err)
 	}
 
@@ -335,6 +284,109 @@ func (c *Client) GetVersionByFileHash(ctx context.Context, fileHash, algorithm s
 }
 
 // --- internal helpers ---
+
+type httpError struct {
+	Operation  string
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("%s failed: status=%d body=%s", e.Operation, e.StatusCode, e.Body)
+}
+
+func (c *Client) get(ctx context.Context, endpoint, operation string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		body, retryAfter, err := c.getOnce(ctx, endpoint, operation)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+
+		var rateLimitErr *RateLimitError
+		if !errors.As(err, &rateLimitErr) || attempt == maxAttempts-1 {
+			return nil, err
+		}
+		wait := retryDelay(attempt, retryAfter)
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) getOnce(ctx context.Context, endpoint, operation string) ([]byte, time.Duration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, 0, fmt.Errorf("read response: %w", err)
+		}
+		return body, 0, nil
+	}
+
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+	body := strings.TrimSpace(string(bodyBytes))
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, retryAfter, &RateLimitError{
+			Operation:  operation,
+			StatusCode: resp.StatusCode,
+			RetryAfter: retryAfter,
+			Body:       body,
+		}
+	}
+	return nil, 0, &httpError{
+		Operation:  operation,
+		StatusCode: resp.StatusCode,
+		Body:       body,
+	}
+}
+
+func retryDelay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > 5*time.Second {
+			return 5 * time.Second
+		}
+		return retryAfter
+	}
+	return time.Duration(attempt+1) * 500 * time.Millisecond
+}
+
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if retryAt, err := http.ParseTime(value); err == nil {
+		if wait := time.Until(retryAt); wait > 0 {
+			return wait
+		}
+	}
+	return 0
+}
 
 type searchResponse struct {
 	Hits      []projectHit `json:"hits"`

--- a/apps/gameservers-service/internal/catalog/modrinth/client_test.go
+++ b/apps/gameservers-service/internal/catalog/modrinth/client_test.go
@@ -59,3 +59,61 @@ func TestGetVersionByFileHashNotFound(t *testing.T) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestGetVersionRetriesRateLimit(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`error code: 1015`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"version-id",
+			"project_id":"project-id",
+			"name":"Release",
+			"version_number":"1.0.0",
+			"version_type":"release",
+			"files":[{"hashes":{"sha1":"abc123"},"primary":true,"filename":"Plugin.jar","url":"https://example.test/plugin.jar","size":123}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client())
+	client.baseURL = server.URL
+
+	version, err := client.GetVersion(context.Background(), "version-id")
+	if err != nil {
+		t.Fatalf("GetVersion returned error: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+	if version.ID != "version-id" {
+		t.Fatalf("unexpected version: %#v", version)
+	}
+}
+
+func TestGetVersionReturnsRateLimitError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`error code: 1015`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client())
+	client.baseURL = server.URL
+
+	_, err := client.GetVersion(context.Background(), "version-id")
+	var rateLimitErr *RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		t.Fatalf("expected RateLimitError, got %v", err)
+	}
+	if rateLimitErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("unexpected status code %d", rateLimitErr.StatusCode)
+	}
+}

--- a/apps/gameservers-service/internal/service/minecraft_catalog.go
+++ b/apps/gameservers-service/internal/service/minecraft_catalog.go
@@ -397,7 +397,7 @@ func (s *Service) InstallMinecraftProjectFile(ctx context.Context, req *connect.
 
 	version, err := s.modClient.GetVersion(ctx, req.Msg.GetVersionId())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to fetch version: %w", err))
+		return nil, modrinthFetchConnectError("failed to fetch version", err)
 	}
 	if !strings.EqualFold(version.ProjectID, req.Msg.GetProjectId()) {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("version does not belong to project"))
@@ -481,7 +481,7 @@ func (s *Service) UpdateMinecraftProjectFile(ctx context.Context, req *connect.R
 
 	version, err := s.modClient.GetVersion(ctx, req.Msg.GetVersionId())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to fetch version: %w", err))
+		return nil, modrinthFetchConnectError("failed to fetch version", err)
 	}
 	if !strings.EqualFold(version.ProjectID, req.Msg.GetProjectId()) {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("version does not belong to project"))
@@ -1217,6 +1217,18 @@ func isStableMinecraftVersion(version modrinth.Version) bool {
 		}
 	}
 	return true
+}
+
+func modrinthFetchConnectError(prefix string, err error) error {
+	var rateLimitErr *modrinth.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		message := "Modrinth is rate limiting plugin metadata requests. Try again shortly."
+		if rateLimitErr.RetryAfter > 0 {
+			message = fmt.Sprintf("Modrinth is rate limiting plugin metadata requests. Try again in about %s.", rateLimitErr.RetryAfter.Round(time.Second))
+		}
+		return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("%s: %s", prefix, message))
+	}
+	return connect.NewError(connect.CodeInternal, fmt.Errorf("%s: %w", prefix, err))
 }
 
 func modrinthTypeToProto(value string) gameserversv1.MinecraftProjectType {

--- a/apps/gameservers-service/internal/service/minecraft_catalog.go
+++ b/apps/gameservers-service/internal/service/minecraft_catalog.go
@@ -274,12 +274,8 @@ func (s *Service) GetMinecraftProjectVersions(ctx context.Context, req *connect.
 	// High-limit requests are used by broad pickers. Plugins should still support
 	// explicit game-version filters, but never get loader auto-filled.
 	skipAutoFill := limit >= 50
-	isPlugin := projectType == gameserversv1.MinecraftProjectType_MINECRAFT_PROJECT_TYPE_PLUGIN
-
 	loaders := dedupeStrings(req.Msg.GetLoaders())
-	if isPlugin {
-		loaders = nil
-	} else if len(loaders) == 0 && !skipAutoFill {
+	if len(loaders) == 0 && !skipAutoFill {
 		if inferred := loaderFromServerType(serverType); inferred != "" {
 			loaders = []string{inferred}
 		}
@@ -405,10 +401,14 @@ func (s *Service) InstallMinecraftProjectFile(ctx context.Context, req *connect.
 	if strings.EqualFold(version.ServerSide, "unsupported") {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("selected version is not server-compatible"))
 	}
+	serverVersion := minecraftServerVersion(dbGameServer.ServerVersion, env)
+	if err := validateMinecraftVersionCompatibility(*version, serverType, projectType, serverVersion); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
 
-	file := selectDownloadFile(version.Files)
+	file := selectDownloadFileForLoader(version.Files, loaderFromServerType(serverType))
 	if file == nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("version has no downloadable files"))
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("version has no downloadable file compatible with %s", serverType))
 	}
 
 	dataPath, installDir, _, err := s.resolveMinecraftInstallDirectory(ctx, dbGameServer.ID, serverType, projectType)
@@ -489,10 +489,14 @@ func (s *Service) UpdateMinecraftProjectFile(ctx context.Context, req *connect.R
 	if strings.EqualFold(version.ServerSide, "unsupported") {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("selected version is not server-compatible"))
 	}
+	serverVersion := minecraftServerVersion(dbGameServer.ServerVersion, env)
+	if err := validateMinecraftVersionCompatibility(*version, serverType, projectType, serverVersion); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
 
-	file := selectDownloadFile(version.Files)
+	file := selectDownloadFileForLoader(version.Files, loaderFromServerType(serverType))
 	if file == nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("version has no downloadable files"))
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("version has no downloadable file compatible with %s", serverType))
 	}
 
 	dataPath, installDir, _, err := s.resolveMinecraftInstallDirectory(ctx, dbGameServer.ID, serverType, projectType)
@@ -1099,10 +1103,8 @@ func (s *Service) latestCompatibleVersion(ctx context.Context, projectID, server
 	if serverVersion != "" {
 		filter.GameVersions = []string{serverVersion}
 	}
-	if projectType != gameserversv1.MinecraftProjectType_MINECRAFT_PROJECT_TYPE_PLUGIN {
-		if loader := loaderFromServerType(serverType); loader != "" {
-			filter.Loaders = []string{loader}
-		}
+	if loaders := compatibleLoadersForServer(serverType, projectType); len(loaders) > 0 {
+		filter.Loaders = loaders
 	}
 
 	versions, err := s.modClient.GetProjectVersions(ctx, projectID, filter)
@@ -1117,7 +1119,10 @@ func (s *Service) latestCompatibleVersion(ctx context.Context, projectID, server
 		if !isStableMinecraftVersion(version) {
 			continue
 		}
-		if selectDownloadFile(version.Files) == nil {
+		if validateMinecraftVersionCompatibility(version, serverType, projectType, serverVersion) != nil {
+			continue
+		}
+		if selectDownloadFileForLoader(version.Files, loaderFromServerType(serverType)) == nil {
 			continue
 		}
 		return &version
@@ -1329,6 +1334,43 @@ func loaderFromServerType(serverType string) string {
 	}
 }
 
+func compatibleLoadersForServer(serverType string, projectType gameserversv1.MinecraftProjectType) []string {
+	loader := loaderFromServerType(serverType)
+	if loader == "" {
+		return nil
+	}
+	if projectType != gameserversv1.MinecraftProjectType_MINECRAFT_PROJECT_TYPE_PLUGIN {
+		return []string{loader}
+	}
+	switch loader {
+	case "purpur":
+		return []string{"purpur", "paper", "spigot", "bukkit"}
+	case "paper":
+		return []string{"paper", "spigot", "bukkit"}
+	case "spigot":
+		return []string{"spigot", "bukkit"}
+	case "bukkit":
+		return []string{"bukkit"}
+	case "folia":
+		return []string{"folia", "paper", "spigot", "bukkit"}
+	case "waterfall":
+		return []string{"waterfall", "bungeecord"}
+	default:
+		return []string{loader}
+	}
+}
+
+func validateMinecraftVersionCompatibility(version modrinth.Version, serverType string, projectType gameserversv1.MinecraftProjectType, serverVersion string) error {
+	if serverVersion != "" && len(version.GameVersions) > 0 && !containsFold(version.GameVersions, serverVersion) {
+		return fmt.Errorf("selected version does not support Minecraft %s", serverVersion)
+	}
+	loaders := compatibleLoadersForServer(serverType, projectType)
+	if len(loaders) > 0 && len(version.Loaders) > 0 && !intersectsFold(version.Loaders, loaders) {
+		return fmt.Errorf("selected version does not support %s", strings.ToUpper(serverType))
+	}
+	return nil
+}
+
 type installProfile struct {
 	InstallDir  string
 	Description string
@@ -1377,21 +1419,125 @@ func isPluginCapableServer(serverType string) bool {
 }
 
 func selectDownloadFile(files []modrinth.VersionFile) *modrinth.VersionFile {
+	return selectDownloadFileForLoader(files, "")
+}
+
+func selectDownloadFileForLoader(files []modrinth.VersionFile, loader string) *modrinth.VersionFile {
 	if len(files) == 0 {
 		return nil
 	}
-	for _, file := range files {
-		if file.Primary {
-			return &file
+	preferred := strings.ToLower(strings.TrimSpace(loader))
+	if preferred != "" {
+		for i := range files {
+			if files[i].Primary && downloadFileMatchesLoader(files[i], preferred) {
+				return &files[i]
+			}
+		}
+		for i := range files {
+			if downloadFileMatchesLoader(files[i], preferred) {
+				return &files[i]
+			}
+		}
+		for i := range files {
+			if files[i].Primary && downloadFileCompatibleWithLoader(files[i], preferred) {
+				return &files[i]
+			}
+		}
+		for i := range files {
+			if downloadFileCompatibleWithLoader(files[i], preferred) {
+				return &files[i]
+			}
+		}
+		return nil
+	}
+	for i := range files {
+		if files[i].Primary {
+			return &files[i]
 		}
 	}
 	// fallback: prefer JAR files
-	for _, file := range files {
-		if strings.HasSuffix(strings.ToLower(file.Filename), ".jar") {
-			return &file
+	for i := range files {
+		if strings.HasSuffix(strings.ToLower(files[i].Filename), ".jar") {
+			return &files[i]
 		}
 	}
 	return &files[0]
+}
+
+func downloadFileMatchesLoader(file modrinth.VersionFile, loader string) bool {
+	name := strings.ToLower(file.Filename)
+	return strings.HasSuffix(name, ".jar") && strings.Contains(name, loader)
+}
+
+func downloadFileCompatibleWithLoader(file modrinth.VersionFile, loader string) bool {
+	name := strings.ToLower(file.Filename)
+	if !strings.HasSuffix(name, ".jar") {
+		return false
+	}
+	allowed := compatibleFilenameMarkersForLoader(loader)
+	for _, marker := range minecraftLoaderFilenameMarkers() {
+		if containsFold(allowed, marker) {
+			continue
+		}
+		if strings.Contains(name, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+func compatibleFilenameMarkersForLoader(loader string) []string {
+	switch loader {
+	case "purpur":
+		return []string{"purpur", "paper", "spigot", "bukkit"}
+	case "paper":
+		return []string{"paper", "spigot", "bukkit"}
+	case "spigot":
+		return []string{"spigot", "bukkit"}
+	case "folia":
+		return []string{"folia", "paper", "spigot", "bukkit"}
+	case "waterfall":
+		return []string{"waterfall", "bungeecord"}
+	default:
+		return []string{loader}
+	}
+}
+
+func minecraftLoaderFilenameMarkers() []string {
+	return []string{
+		"bukkit",
+		"spigot",
+		"paper",
+		"purpur",
+		"folia",
+		"velocity",
+		"waterfall",
+		"bungeecord",
+		"forge",
+		"neoforge",
+		"fabric",
+		"quilt",
+		"magma",
+		"catserver",
+	}
+}
+
+func containsFold(values []string, expected string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func intersectsFold(left, right []string) bool {
+	for _, l := range left {
+		if containsFold(right, l) {
+			return true
+		}
+	}
+	return false
 }
 
 func encodeCursor(offset int) string {

--- a/apps/gameservers-service/internal/service/minecraft_catalog_test.go
+++ b/apps/gameservers-service/internal/service/minecraft_catalog_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"gameservers-service/internal/catalog/modrinth"
+
+	gameserversv1 "github.com/obiente/cloud/apps/shared/proto/obiente/cloud/gameservers/v1"
 )
 
 func TestMatchingVersionFilePrefersHash(t *testing.T) {
@@ -131,5 +133,66 @@ func TestIsStableMinecraftVersion(t *testing.T) {
 				t.Fatalf("expected stable=%v, got %v", tt.stable, got)
 			}
 		})
+	}
+}
+
+func TestValidateMinecraftVersionCompatibilityRejectsWrongLoader(t *testing.T) {
+	version := modrinth.Version{
+		VersionNumber: "5.10.0",
+		GameVersions:  []string{"1.21.5"},
+		Loaders:       []string{"velocity"},
+	}
+
+	err := validateMinecraftVersionCompatibility(version, "PAPER", gameserversv1.MinecraftProjectType_MINECRAFT_PROJECT_TYPE_PLUGIN, "1.21.5")
+	if err == nil {
+		t.Fatal("expected Paper server to reject Velocity plugin version")
+	}
+}
+
+func TestValidateMinecraftVersionCompatibilityRejectsWrongGameVersion(t *testing.T) {
+	version := modrinth.Version{
+		VersionNumber: "5.10.0",
+		GameVersions:  []string{"1.20.1"},
+		Loaders:       []string{"paper"},
+	}
+
+	err := validateMinecraftVersionCompatibility(version, "PAPER", gameserversv1.MinecraftProjectType_MINECRAFT_PROJECT_TYPE_PLUGIN, "1.21.5")
+	if err == nil {
+		t.Fatal("expected Minecraft 1.21.5 server to reject 1.20.1 plugin version")
+	}
+}
+
+func TestValidateMinecraftVersionCompatibilityAllowsPaperCompatiblePlugin(t *testing.T) {
+	version := modrinth.Version{
+		VersionNumber: "5.10.0",
+		GameVersions:  []string{"1.21.5"},
+		Loaders:       []string{"spigot"},
+	}
+
+	err := validateMinecraftVersionCompatibility(version, "PAPER", gameserversv1.MinecraftProjectType_MINECRAFT_PROJECT_TYPE_PLUGIN, "1.21.5")
+	if err != nil {
+		t.Fatalf("expected Paper server to accept Spigot-compatible plugin version: %v", err)
+	}
+}
+
+func TestSelectDownloadFileForLoaderPrefersMatchingJar(t *testing.T) {
+	files := []modrinth.VersionFile{
+		{Primary: true, Filename: "Plugin-Velocity.jar"},
+		{Filename: "Plugin-Paper.jar"},
+	}
+
+	file := selectDownloadFileForLoader(files, "paper")
+	if file == nil || file.Filename != "Plugin-Paper.jar" {
+		t.Fatalf("expected paper jar, got %#v", file)
+	}
+}
+
+func TestSelectDownloadFileForLoaderRejectsIncompatibleJar(t *testing.T) {
+	files := []modrinth.VersionFile{
+		{Primary: true, Filename: "Plugin-Velocity.jar"},
+	}
+
+	if file := selectDownloadFileForLoader(files, "paper"); file != nil {
+		t.Fatalf("expected no compatible paper jar, got %#v", file)
 	}
 }


### PR DESCRIPTION
## Summary
- retry transient Modrinth 429 responses with bounded backoff
- return a resource-exhausted error when Modrinth continues rate-limiting plugin metadata requests
- enforce Minecraft game-version and loader compatibility during install/update RPCs
- prevent Paper/Purpur/Spigot plugin updates from selecting Velocity/Waterfall artifacts
- choose a loader-compatible jar when a Modrinth version publishes multiple downloads

## Verification
- go test ./internal/catalog/modrinth ./internal/service