### PR TITLE
Reduce dashboard render and startup work

### DIFF
--- a/apps/dashboard/app/components/gameserver/MinecraftModsBrowser.vue
+++ b/apps/dashboard/app/components/gameserver/MinecraftModsBrowser.vue
@@ -245,8 +245,8 @@
         ]"
       >
         <OuiCard
-          v-for="project in projects"
-          :key="project.id"
+          v-for="card in projectCards"
+          :key="card.project.id"
           variant="default"
           class="border-border-muted/70 hover:border-border-default transition"
         >
@@ -255,47 +255,47 @@
               <OuiFlex gap="md" align="start">
                 <OuiAvatar
                   size="lg"
-                  :src="project.iconUrl || undefined"
+                  :src="card.project.iconUrl || undefined"
                   class="bg-surface-muted shrink-0"
-                  :alt="project.title"
+                  :alt="card.project.title"
                 >
-                  <CubeIcon v-if="!project.iconUrl" class="w-5 h-5 text-secondary" />
+                  <CubeIcon v-if="!card.project.iconUrl" class="w-5 h-5 text-secondary" />
                 </OuiAvatar>
                 <OuiStack gap="xs" class="flex-1 min-w-0">
                   <OuiFlex align="center" gap="sm" wrap="wrap">
-                    <OuiText as="h3" size="lg" weight="semibold" truncate>{{ project.title }}</OuiText>
+                    <OuiText as="h3" size="lg" weight="semibold" truncate>{{ card.project.title }}</OuiText>
                     <OuiBadge
-                      v-for="typeLabel in getProjectTypeLabels(project)"
-                      :key="`project-type-${project.id}-${typeLabel}`"
+                      v-for="typeLabel in card.typeLabels"
+                      :key="`project-type-${card.project.id}-${typeLabel}`"
                       size="xs"
                       variant="secondary"
                     >
                       {{ typeLabel }}
                     </OuiBadge>
                     <OuiBadge
-                      v-if="getInstalledProject(project)"
+                      v-if="card.installedFile"
                       size="xs"
-                      :variant="getInstalledProject(project)?.updateAvailable ? 'warning' : 'success'"
+                      :variant="card.installedFile.updateAvailable ? 'warning' : 'success'"
                     >
-                      {{ getInstalledProject(project)?.updateAvailable ? 'Update available' : 'Installed' }}
+                      {{ card.installedFile.updateAvailable ? 'Update available' : 'Installed' }}
                     </OuiBadge>
                   </OuiFlex>
                   <OuiText size="sm" color="tertiary" :lineClamp="2">
-                    {{ project.description || "No description provided." }}
+                    {{ card.project.description || "No description provided." }}
                   </OuiText>
                 </OuiStack>
               </OuiFlex>
 
               <OuiStack gap="xs">
                 <OuiFlex
-                  v-if="(project.loaders?.length || 0) > 0"
+                  v-if="card.visibleLoaders.length > 0"
                   wrap="wrap"
                   gap="xs"
                   align="center"
                 >
                   <OuiBadge
-                    v-for="loader in (project.loaders || []).slice(0, 3)"
-                    :key="`loader-${project.id}-${loader}`"
+                    v-for="loader in card.visibleLoaders"
+                    :key="`loader-${card.project.id}-${loader}`"
                     size="xs"
                     variant="primary"
                     tone="soft"
@@ -303,24 +303,24 @@
                     {{ loader }}
                   </OuiBadge>
                   <OuiBadge
-                    v-if="(project.loaders?.length || 0) > 3"
+                    v-if="card.loaderOverflow > 0"
                     size="xs"
                     variant="primary"
                     tone="soft"
                   >
-                    +{{ (project.loaders?.length || 0) - 3 }}
+                    +{{ card.loaderOverflow }}
                   </OuiBadge>
                 </OuiFlex>
 
                 <OuiFlex
-                  v-if="displayableCategories(project).length > 0"
+                  v-if="card.visibleCategories.length > 0"
                   wrap="wrap"
                   gap="xs"
                   align="center"
                 >
                   <OuiBadge
-                    v-for="category in displayableCategories(project).slice(0, 4)"
-                    :key="`category-${project.id}-${category}`"
+                    v-for="category in card.visibleCategories"
+                    :key="`category-${card.project.id}-${category}`"
                     size="xs"
                     variant="secondary"
                     tone="soft"
@@ -328,17 +328,17 @@
                     {{ formatCategory(category) }}
                   </OuiBadge>
                   <OuiBadge
-                    v-if="displayableCategories(project).length > 4"
+                    v-if="card.categoryOverflow > 0"
                     size="xs"
                     variant="secondary"
                     tone="soft"
                   >
-                    +{{ displayableCategories(project).length - 4 }}
+                    +{{ card.categoryOverflow }}
                   </OuiBadge>
                 </OuiFlex>
 
                 <OuiFlex
-                  v-if="(project.gameVersions?.length || 0) > 0"
+                  v-if="card.versionRange"
                   wrap="wrap"
                   gap="xs"
                   align="center"
@@ -348,7 +348,7 @@
                     variant="secondary"
                     tone="soft"
                   >
-                    {{ formatVersionRange(project.gameVersions || []) }}
+                    {{ card.versionRange }}
                   </OuiBadge>
                 </OuiFlex>
               </OuiStack>
@@ -357,20 +357,20 @@
                 <OuiStack gap="xs">
                   <OuiText size="xs" color="tertiary">Downloads</OuiText>
                   <OuiText size="sm" weight="semibold" color="primary">
-                    {{ formatDownloads(project.downloads) }}
+                    {{ card.downloadsLabel }}
                   </OuiText>
                 </OuiStack>
-                <OuiStack gap="xs" v-if="activeVersionFilter && project.gameVersions && project.gameVersions.length > 0">
+                <OuiStack gap="xs" v-if="activeVersionFilter && card.versionRange">
                   <OuiText size="xs" color="tertiary">Compatibility</OuiText>
                   <OuiFlex gap="xs" align="center">
                     <OuiBadge
                       size="xs"
-                      :variant="getCompatibilityStatus(project).variant"
+                      :variant="card.compatibility.variant"
                     >
-                      {{ getCompatibilityStatus(project).label }}
+                      {{ card.compatibility.label }}
                     </OuiBadge>
-                    <OuiText v-if="getCompatibilityStatus(project).range" size="xs" color="tertiary">
-                      {{ getCompatibilityStatus(project).range }}
+                    <OuiText v-if="card.compatibility.range" size="xs" color="tertiary">
+                      {{ card.compatibility.range }}
                     </OuiText>
                   </OuiFlex>
                 </OuiStack>
@@ -379,7 +379,7 @@
                     size="sm"
                     variant="ghost"
                     class="gap-2"
-                    @click="openOverview(project)"
+                    @click="openOverview(card.project)"
                   >
                     <EyeIcon class="w-4 h-4" />
                     Details
@@ -388,12 +388,12 @@
                     size="sm"
                     class="gap-2"
                     variant="soft"
-                    :loading="selectedProject?.id === project.id && installDialogOpen && isVersionsLoading"
-                    @click="openInstallDialog(project, getInstalledProject(project) || undefined)"
+                    :loading="selectedProject?.id === card.project.id && installDialogOpen && isVersionsLoading"
+                    @click="openInstallDialog(card.project, card.installedFile || undefined)"
                   >
-                    <ArrowPathIcon v-if="getInstalledProject(project)?.updateAvailable" class="w-4 h-4" />
+                    <ArrowPathIcon v-if="card.installedFile?.updateAvailable" class="w-4 h-4" />
                     <CloudArrowDownIcon v-else class="w-4 h-4" />
-                    {{ getInstalledProject(project) ? 'Update' : 'Install' }}
+                    {{ card.installedFile ? 'Update' : 'Install' }}
                   </OuiButton>
                 </OuiFlex>
               </OuiFlex>
@@ -736,7 +736,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
 import {
   ArrowPathIcon,
   CloudArrowDownIcon,
@@ -791,6 +791,19 @@ interface DetachedWindow {
   size: { width: number; height: number };
 }
 
+interface ProjectCardView {
+  project: MinecraftProject;
+  installedFile: InstalledMinecraftProjectFile | null;
+  typeLabels: string[];
+  visibleLoaders: string[];
+  loaderOverflow: number;
+  visibleCategories: string[];
+  categoryOverflow: number;
+  versionRange: string;
+  compatibility: { label: string; variant: "success" | "warning" | "secondary"; range?: string };
+  downloadsLabel: string;
+}
+
 const PAGE_SIZE = 18;
 const INITIAL_SKELETON_COUNT = 6;
 
@@ -803,8 +816,8 @@ const props = defineProps<{
 const client = useConnectClient(GameServerService);
 const { toast } = useToast();
 
-const projects = ref<MinecraftProject[]>([]);
-const installedFiles = ref<InstalledMinecraftProjectFile[]>([]);
+const projects = shallowRef<MinecraftProject[]>([]);
+const installedFiles = shallowRef<InstalledMinecraftProjectFile[]>([]);
 const cursor = ref<string | undefined>();
 const hasMore = ref(false);
 const isLoading = ref(false);
@@ -923,7 +936,7 @@ const activeLoaderFilter = computed(() => {
 const installDialogOpen = ref(false);
 const selectedProject = ref<MinecraftProject | null>(null);
 const selectedInstalledFile = ref<InstalledMinecraftProjectFile | null>(null);
-const versionOptions = ref<MinecraftProjectVersion[]>([]);
+const versionOptions = shallowRef<MinecraftProjectVersion[]>([]);
 const selectedVersionId = ref<string>("");
 const includePrereleaseVersions = ref(false);
 const isVersionsLoading = ref(false);
@@ -937,6 +950,8 @@ const windowPosition = ref({ x: 100, y: 100 });
 const windowSize = ref({ width: 800, height: 600 });
 let tabCounter = 0;
 let detachedWindowCounter = 0;
+let loadProjectsRequestId = 0;
+let loadInstalledRequestId = 0;
 
 const installDialogTitle = computed(() =>
   selectedProject.value
@@ -1015,6 +1030,25 @@ const installedByProjectId = computed(() => {
     }
   }
   return map;
+});
+
+const projectCards = computed<ProjectCardView[]>(() => {
+  const installed = installedByProjectId.value;
+  return projects.value.map((project) => {
+    const displayCategories = displayableCategories(project);
+    return {
+      project,
+      installedFile: installed.get(project.id) || null,
+      typeLabels: getProjectTypeLabels(project),
+      visibleLoaders: (project.loaders || []).slice(0, 3),
+      loaderOverflow: Math.max(0, (project.loaders?.length || 0) - 3),
+      visibleCategories: displayCategories.slice(0, 4),
+      categoryOverflow: Math.max(0, displayCategories.length - 4),
+      versionRange: (project.gameVersions?.length || 0) > 0 ? formatVersionRange(project.gameVersions || []) : "",
+      compatibility: getCompatibilityStatus(project),
+      downloadsLabel: formatDownloads(project.downloads),
+    };
+  });
 });
 
 const updateableInstalledFiles = computed(() =>
@@ -1134,9 +1168,12 @@ function createSkeletonState(): SkeletonCardState {
 
 async function loadProjects(opts: { reset?: boolean } = {}) {
   if (!props.gameServerId) return;
+  const requestId = ++loadProjectsRequestId;
   const isReset = Boolean(opts.reset);
   if (isReset) {
     isLoading.value = true;
+    isLoadingMore.value = false;
+    infiniteSkeletons.value = [];
     isRefreshing.value = hasLoadedOnce.value && projects.value.length > 0;
     if (!hasLoadedOnce.value || projects.value.length === 0) {
       projects.value = [];
@@ -1148,6 +1185,7 @@ async function loadProjects(opts: { reset?: boolean } = {}) {
   try {
     const payload = buildQueryPayload(cursor.value);
     const response = await client.listMinecraftProjects(payload);
+    if (requestId !== loadProjectsRequestId) return;
     const fetchedProjects = response.projects ?? [];
     const fetchedCount = fetchedProjects.length;
     if (isReset) {
@@ -1162,10 +1200,12 @@ async function loadProjects(opts: { reset?: boolean } = {}) {
       regenerateInfiniteSkeletons(fetchedCount);
     }
   } catch (err: unknown) {
+    if (requestId !== loadProjectsRequestId) return;
     console.error(err);
     errorMessage.value = (err as Error | undefined)?.message ?? "Failed to load catalog";
     toast.error("Failed to load Minecraft catalog", errorMessage.value || undefined);
   } finally {
+    if (requestId !== loadProjectsRequestId) return;
     if (isReset) {
       isLoading.value = false;
       isRefreshing.value = false;
@@ -1175,6 +1215,7 @@ async function loadProjects(opts: { reset?: boolean } = {}) {
 
 async function loadInstalledFiles() {
   if (!props.gameServerId) return;
+  const requestId = ++loadInstalledRequestId;
   isInstalledLoading.value = true;
   installedErrorMessage.value = null;
   try {
@@ -1183,12 +1224,15 @@ async function loadInstalledFiles() {
       projectType: projectType.value,
       checkUpdates: true,
     });
+    if (requestId !== loadInstalledRequestId) return;
     installedFiles.value = response.files ?? [];
   } catch (err: unknown) {
+    if (requestId !== loadInstalledRequestId) return;
     console.error(err);
     installedErrorMessage.value = (err as Error | undefined)?.message ?? "Failed to load installed content";
     toast.error("Failed to load installed content", installedErrorMessage.value || undefined);
   } finally {
+    if (requestId !== loadInstalledRequestId) return;
     isInstalledLoading.value = false;
   }
 }
@@ -1794,8 +1838,9 @@ async function installSelected() {
   }
 }
 
-async function updateInstalledFile(file: InstalledMinecraftProjectFile) {
+async function updateInstalledFile(file: InstalledMinecraftProjectFile, opts: { refreshInstalled?: boolean } = {}) {
   if (!file.projectId) return;
+  const refreshInstalled = opts.refreshInstalled ?? true;
   const targetVersionId = file.latestVersionId || file.versionId;
   if (!targetVersionId) return;
   updatingFilename.value = file.filename;
@@ -1811,7 +1856,9 @@ async function updateInstalledFile(file: InstalledMinecraftProjectFile) {
       projectIconUrl: file.iconUrl,
     });
     toast.success(`${file.title || file.filename} updated`, "Restart the server to apply the change.");
-    await loadInstalledFiles();
+    if (refreshInstalled) {
+      await loadInstalledFiles();
+    }
   } catch (err: unknown) {
     console.error(err);
     toast.error("Failed to update", (err as Error | undefined)?.message || "Unknown error");
@@ -1824,9 +1871,11 @@ async function updateAllAvailable() {
   if (updateableInstalledFiles.value.length === 0) return;
   isBulkUpdating.value = true;
   try {
-    for (const file of updateableInstalledFiles.value) {
-      await updateInstalledFile(file);
+    const filesToUpdate = [...updateableInstalledFiles.value];
+    for (const file of filesToUpdate) {
+      await updateInstalledFile(file, { refreshInstalled: false });
     }
+    await loadInstalledFiles();
   } finally {
     isBulkUpdating.value = false;
   }

--- a/apps/dashboard/app/composables/useAuth.ts
+++ b/apps/dashboard/app/composables/useAuth.ts
@@ -1,7 +1,12 @@
 import { appendResponseHeader } from "h3";
-import { getCurrentInstance, nextTick, onMounted, onUnmounted } from "vue";
 import type { User, UserSession } from "@obiente/types";
 import { useOrganizationsStore } from "~/stores/organizations";
+
+let clientAuthInitialized = false;
+let clientAuthInitScheduled = false;
+let clientTokenCheckInterval: ReturnType<typeof setInterval> | null = null;
+let sessionWatcherStarted = false;
+let tokenFetchInProgress = false;
 
 export const useAuth = () => {
   const serverEvent = import.meta.server ? useRequestEvent() : null;
@@ -489,193 +494,122 @@ export const useAuth = () => {
     return hasSession();
   };
 
-  // Track if token fetch is in progress to prevent concurrent calls
-  let tokenFetchInProgress = false;
-
-  watch(
-    () => sessionState.value,
-    async (newSession, oldSession) => {
-      // Prevent concurrent token fetches
-      if (tokenFetchInProgress) {
-        return;
-      }
-
-      // Only fetch token if session actually changed (not just on mount)
-      // Use deep equality check to prevent unnecessary triggers
-      if (newSession && newSession !== oldSession) {
-        // Check if session actually changed (compare user sub to avoid unnecessary updates)
-        const newUserSub = newSession?.user?.sub;
-        const oldUserSub = oldSession?.user?.sub;
-
-        // If user sub is the same and we have a token, skip
-        if (
-          newUserSub &&
-          oldUserSub &&
-          newUserSub === oldUserSub &&
-          accessToken.value
-        ) {
-          // Session object reference changed but user is the same - skip
+  if (import.meta.client && !sessionWatcherStarted) {
+    sessionWatcherStarted = true;
+    watch(
+      () => sessionState.value,
+      async (newSession, oldSession) => {
+        if (tokenFetchInProgress) {
           return;
         }
 
-        try {
-          if (import.meta.client) {
-            // Only fetch if we don't have a valid token already
+        if (newSession && newSession !== oldSession) {
+          const newUserSub = newSession?.user?.sub;
+          const oldUserSub = oldSession?.user?.sub;
+
+          if (
+            newUserSub &&
+            oldUserSub &&
+            newUserSub === oldUserSub &&
+            accessToken.value
+          ) {
+            return;
+          }
+
+          try {
             if (
-              !accessToken.value ||
-              (tokenExpiry.value && Date.now() >= tokenExpiry.value)
+              import.meta.client &&
+              (!accessToken.value ||
+                (tokenExpiry.value && Date.now() >= tokenExpiry.value))
             ) {
-              // Defer token fetch to avoid blocking during hydration
               tokenFetchInProgress = true;
 
-              // Use requestAnimationFrame to defer until after hydration
-              requestAnimationFrame(() => {
-                requestAnimationFrame(async () => {
-                  try {
-                    const response = await $fetch<{
-                      accessToken: string;
-                      expiresIn?: number;
-                    }>("/auth/token");
-                    if (response.accessToken) {
-                      accessToken.value = response.accessToken;
-                      if (response.expiresIn) {
-                        tokenExpiry.value =
-                          Date.now() + response.expiresIn * 1000 - 30000;
-                      }
+              requestAnimationFrame(async () => {
+                try {
+                  const response = await $fetch<{
+                    accessToken: string;
+                    expiresIn?: number;
+                  }>("/auth/token");
+                  if (response.accessToken) {
+                    accessToken.value = response.accessToken;
+                    if (response.expiresIn) {
+                      tokenExpiry.value =
+                        Date.now() + response.expiresIn * 1000 - 30000;
                     }
-                  } catch (e) {
-                    console.error(
-                      "[useAuth] Failed to fetch token after session update:",
-                      e
-                    );
-                  } finally {
-                    tokenFetchInProgress = false;
                   }
-                });
+                } catch (e) {
+                  console.error(
+                    "[useAuth] Failed to fetch token after session update:",
+                    e
+                  );
+                } finally {
+                  tokenFetchInProgress = false;
+                }
               });
             }
+          } catch (e) {
+            console.error(
+              "[useAuth] Failed to fetch token after session update:",
+              e
+            );
+            tokenFetchInProgress = false;
           }
-        } catch (e) {
-          console.error(
-            "[useAuth] Failed to fetch token after session update:",
-            e
-          );
-          tokenFetchInProgress = false;
+        } else if (!newSession && oldSession) {
+          accessToken.value = null;
+          tokenExpiry.value = null;
         }
-      } else if (!newSession && oldSession) {
-        // Session was cleared
-        accessToken.value = null;
-        tokenExpiry.value = null;
-      }
-    },
-    { immediate: false } // Don't run immediately - let onMounted handle initial fetch
-  );
-
-  // Initialize auth - defer heavy operations until after hydration to prevent Chrome freeze
-  // Use getCurrentInstance safely (may be null during hydration)
-  let instance: ReturnType<typeof getCurrentInstance> | null = null;
-  try {
-    instance = getCurrentInstance();
-  } catch (e) {
-    // getCurrentInstance may fail during hydration - treat as non-component context
-    instance = null;
+      },
+      { immediate: false }
+    );
   }
-
-  // Store interval ID for cleanup
-  let tokenCheckInterval: ReturnType<typeof setInterval> | null = null;
 
   const initializeAuth = () => {
     if (import.meta.client) {
-      // Defer fetch() to avoid blocking during hydration
-      // Use multiple requestAnimationFrame calls to ensure hydration is fully complete
+      if (clientAuthInitialized) {
+        return;
+      }
+      clientAuthInitialized = true;
+
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          fetch()
-            .then(() => {
-              // fetch completed
-            })
-            .catch((err) => {
-              console.error("[useAuth] fetch() error:", err);
-            });
+        fetch().catch((err) => {
+          console.error("[useAuth] fetch() error:", err);
+        });
 
-          // Try silent auth first if no session exists (defer to avoid blocking hydration)
-          if (!sessionState.value || !user.value) {
-            // Use multiple deferrals to ensure hydration is complete
-            // requestAnimationFrame ensures DOM is ready, then setTimeout gives extra time
-            setTimeout(() => {
-              trySilentAuth()
-                .then((success) => {
-                  if (!success) {
-                    // Silent auth failed, but don't auto-open popup here
-                    // Let the middleware handle it if needed
-                  }
-                })
-                .catch((err) => {
-                  console.error("[useAuth] trySilentAuth error:", err);
-                });
-            }, 500); // Increased delay to ensure hydration completes
-          }
+        if (!sessionState.value || !user.value) {
+          setTimeout(() => {
+            trySilentAuth()
+              .then((success) => {
+                if (!success) {
+                  // Silent auth failed, but don't auto-open popup here
+                  // Let the middleware handle it if needed
+                }
+              })
+              .catch((err) => {
+                console.error("[useAuth] trySilentAuth error:", err);
+              });
+          }, 500);
+        }
 
-          tokenCheckInterval = setInterval(() => {
+        if (!clientTokenCheckInterval) {
+          clientTokenCheckInterval = setInterval(() => {
             if (tokenExpiry.value && Date.now() >= tokenExpiry.value) {
               refreshAccessToken(true).catch(console.error);
             }
           }, 60 * 1000);
-        });
+        }
       });
     } else {
-      // Server-side: just fetch
       fetch();
     }
   };
 
-  if (instance) {
-    // We're in a component context - use lifecycle hooks
-    onMounted(() => {
-      // Defer initialization until after hydration using multiple deferrals
-      // Use queueMicrotask to get out of the current execution context (microtask queue)
-      queueMicrotask(() => {
-        // Then use setTimeout to get to the next macrotask
-        setTimeout(() => {
-          // Then use requestAnimationFrame to ensure DOM is ready
-          requestAnimationFrame(() => {
-            // One more requestAnimationFrame to ensure hydration is fully complete
-            requestAnimationFrame(() => {
-              initializeAuth();
-            });
-          });
-        }, 0);
-      });
-    });
-
-    onUnmounted(() => {
-      if (tokenCheckInterval) {
-        clearInterval(tokenCheckInterval);
-        tokenCheckInterval = null;
-      }
-      // Clean up popup event listeners on unmount to prevent leaks
-      if (messageListenerActive) {
-        window.removeEventListener("message", messageListener);
-        messageListenerActive = false;
-      }
-      if (popupListenerActive) {
-        window.removeEventListener("storage", popupListener);
-        popupListenerActive = false;
-      }
-    });
-  } else {
-    // Not in component context (e.g., called from plugin) - defer initialization
-    if (import.meta.client) {
-      // Use requestAnimationFrame to defer until after hydration
-      requestAnimationFrame(() => {
-        nextTick(() => {
-          initializeAuth();
-        });
-      });
-    } else {
-      // Server-side: initialize immediately
-      initializeAuth();
+  if (import.meta.client) {
+    if (!clientAuthInitScheduled && !clientAuthInitialized) {
+      clientAuthInitScheduled = true;
+      setTimeout(initializeAuth, 0);
     }
+  } else {
+    initializeAuth();
   }
 
   // Create computed properties lazily to avoid triggering during initialization

--- a/apps/dashboard/app/plugins/highlight.client.ts
+++ b/apps/dashboard/app/plugins/highlight.client.ts
@@ -4,51 +4,57 @@ export default defineNuxtPlugin({
   async setup() {
     if (typeof window === "undefined") return;
 
-    // Import highlight.js - handle both default and named exports for v11 compatibility
-    let highlightInstance: any;
-    try {
-      const hljs = await import("highlight.js");
-      // highlight.js v11 uses default export
-      highlightInstance = hljs.default || hljs;
-      
-      // If it's still not available, try named imports
-      if (!highlightInstance && (hljs as any).highlight) {
-        highlightInstance = hljs;
-      }
-    } catch (err) {
-      console.error("Failed to load highlight.js:", err);
-      return;
-    }
-    
-    if (!highlightInstance) {
-      console.error("highlight.js instance not available");
-      return;
-    }
-    
-    // Import and apply OUI theme utility
-    const { applyOUIThemeToHighlightJS } = await import("~/utils/highlight-theme");
-    
-    // Apply OUI theme to highlight.js
-    applyOUIThemeToHighlightJS();
+    let highlightInstance: any = null;
+    let highlightLoadPromise: Promise<any> | null = null;
 
-    // Make highlight.js available globally
-    (window as any).hljs = highlightInstance;
+    const ensureHighlight = async () => {
+      if (highlightInstance) return highlightInstance;
+      if (!highlightLoadPromise) {
+        highlightLoadPromise = Promise.all([
+          import("highlight.js"),
+          import("~/utils/highlight-theme"),
+        ])
+          .then(([hljs, theme]) => {
+            highlightInstance = hljs.default || hljs;
+            if (!highlightInstance && (hljs as any).highlight) {
+              highlightInstance = hljs;
+            }
+            if (!highlightInstance) {
+              throw new Error("highlight.js instance not available");
+            }
+            theme.applyOUIThemeToHighlightJS();
+            (window as any).hljs = highlightInstance;
+            return highlightInstance;
+          })
+          .catch((err) => {
+            highlightLoadPromise = null;
+            console.error("Failed to load highlight.js:", err);
+            return null;
+          });
+      }
+      return highlightLoadPromise;
+    };
 
     // Helper function to highlight code blocks
-    const highlightCodeBlocks = () => {
-      if (typeof window === "undefined" || !highlightInstance) return;
-      
-      document.querySelectorAll("pre code").forEach((block) => {
+    const highlightCodeBlocks = async () => {
+      if (typeof window === "undefined") return;
+      const blocks = Array.from(document.querySelectorAll("pre code:not(.hljs)"));
+      if (blocks.length === 0) return;
+
+      const highlighter = await ensureHighlight();
+      if (!highlighter) return;
+
+      blocks.forEach((block) => {
         // Only highlight if not already highlighted
         if (!block.classList.contains("hljs")) {
           // Use highlightElement if available, otherwise use highlight API
-          if (highlightInstance.highlightElement) {
-            highlightInstance.highlightElement(block as HTMLElement);
-          } else if (highlightInstance.highlight) {
+          if (highlighter.highlightElement) {
+            highlighter.highlightElement(block as HTMLElement);
+          } else if (highlighter.highlight) {
             const code = block.textContent || "";
             const language = block.className.match(/language-(\w+)/)?.[1] || "plaintext";
             try {
-              const result = highlightInstance.highlight(code, { language });
+              const result = highlighter.highlight(code, { language });
               block.innerHTML = result.value;
               block.classList.add("hljs");
             } catch {
@@ -66,9 +72,9 @@ export default defineNuxtPlugin({
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (document.readyState === "loading") {
-            document.addEventListener("DOMContentLoaded", highlightCodeBlocks);
+            document.addEventListener("DOMContentLoaded", () => void highlightCodeBlocks(), { once: true });
           } else {
-            highlightCodeBlocks();
+            void highlightCodeBlocks();
           }
         });
       });
@@ -82,7 +88,7 @@ export default defineNuxtPlugin({
       const router = useRouter();
       if (router) {
         router.afterEach(() => {
-          setTimeout(highlightCodeBlocks, 100);
+          setTimeout(() => void highlightCodeBlocks(), 100);
         });
       }
     } catch {
@@ -90,4 +96,3 @@ export default defineNuxtPlugin({
     }
   },
 });
-


### PR DESCRIPTION
## Summary
- precompute Minecraft plugin browser card data instead of recalculating category/version/compatibility state during every render
- store large project, installed-file, and version arrays as shallow refs to avoid deep proxying read-only protobuf payloads
- discard stale catalog and installed-file responses when filters or server metadata change quickly
- refresh installed plugin state once after bulk updates instead of after every individual update
- make auth initialization single-run on the client so repeated useAuth() calls do not create duplicate session fetches, silent-auth checks, watchers, or token refresh intervals
- lazy-load highlight.js only on pages that actually contain code blocks

## Verification
- pnpm --dir apps/dashboard exec vue-tsc --noEmit --project tsconfig.json