### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/docker-compose.swarm.ha.yml
+++ b/docker-compose.swarm.ha.yml
@@ -43,7 +43,7 @@ services:
 
   # HAProxy - PostgreSQL connection pooler and load balancer
   pgpool:
-    image: bitnami/pgpool:4
+    image: soldevelo/pgpool:4
     environment:
       PGPOOL_BACKEND_NODES: 0:patroni-1:5432,1:patroni-2:5432,2:patroni-3:5432
       PGPOOL_SR_CHECK_USER: ${POSTGRES_USER:-obiente_postgres}
@@ -189,7 +189,7 @@ services:
 
   # PgPool for TimescaleDB - Connection pooler and load balancer
   metrics-pgpool:
-    image: bitnami/pgpool:4
+    image: soldevelo/pgpool:4
     environment:
       PGPOOL_BACKEND_NODES: 0:metrics-patroni-1:5432,1:metrics-patroni-2:5432,2:metrics-patroni-3:5432
       PGPOOL_SR_CHECK_USER: ${METRICS_DB_USER:-obiente_postgres}


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/pgpool:4` → [`soldevelo/pgpool:4`](https://hub.docker.com/r/soldevelo/pgpool)