### PR TITLE
fix(auth): keep ZITADEL login interactive

### DIFF
--- a/apps/dashboard/server/routes/auth/oauth-login.ts
+++ b/apps/dashboard/server/routes/auth/oauth-login.ts
@@ -11,13 +11,6 @@ export default eventHandler(async (event) => {
 
   const { code_challenge, code_challenge_method } = await handlePKCE(event);
 
-  // Check for existing session cookie to determine if we should use silent auth
-  const { AUTH_COOKIE_NAME } = await import("../../utils/auth");
-  const sessionCookie = getCookie(event, AUTH_COOKIE_NAME);
-  // If no session cookie exists, try silent auth (check if user is logged into Zitadel)
-  // If session cookie exists, don't use prompt (let Zitadel use existing session)
-  const isSilent = !sessionCookie;
-
   const params = new URLSearchParams({
     client_id: OIDC.clientId,
     redirect_uri: config.public.requestHost + OIDC.redirectPath,
@@ -27,11 +20,10 @@ export default eventHandler(async (event) => {
     code_challenge_method: code_challenge_method!,
   });
 
-  // Use silent auth if no local session, otherwise let Zitadel handle it naturally
-  // NOT using prompt: "login" because that prevents session persistence
-  if (isSilent) {
-    params.set("prompt", "none");
-  }
-
+  // This route is opened by an explicit user action, so it must remain
+  // interactive. Omitting prompt lets Zitadel reuse a valid session or show its
+  // login UI. prompt=none is reserved for /auth/silent-check; with Login V2 it
+  // returns a raw "No active session found" response when the browser only has
+  // stale or unusable Zitadel sessions.
   sendRedirect(event, `${OIDC.authority}/authorize?${params.toString()}`);
 });

--- a/apps/dashboard/tests/oauthLoginRoute.test.ts
+++ b/apps/dashboard/tests/oauthLoginRoute.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("interactive OAuth login route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not request silent authentication when there is no local session", async () => {
+    const sendRedirect = vi.fn();
+
+    vi.stubGlobal("eventHandler", <T>(handler: T) => handler);
+    vi.stubGlobal("useRuntimeConfig", () => ({
+      public: {
+        oidcBase: "https://auth.obiente.cloud",
+        oidcClientId: "dashboard-client",
+        requestHost: "https://cloud.obiente.org",
+      },
+    }));
+    vi.stubGlobal("handlePKCE", async () => ({
+      code_challenge: "test-challenge",
+      code_challenge_method: "S256",
+    }));
+    vi.stubGlobal("sendRedirect", sendRedirect);
+
+    const { default: oauthLogin } = await import(
+      "../server/routes/auth/oauth-login"
+    );
+
+    await oauthLogin({} as never);
+
+    expect(sendRedirect).toHaveBeenCalledOnce();
+    const authorizationUrl = new URL(sendRedirect.mock.calls[0][1] as string);
+
+    expect(authorizationUrl.origin).toBe("https://auth.obiente.cloud");
+    expect(authorizationUrl.pathname).toBe("/oauth/v2/authorize");
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://cloud.obiente.org/auth/callback"
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge")).toBe(
+      "test-challenge"
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256"
+    );
+    expect(authorizationUrl.searchParams.has("prompt")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- remove the local-session-cookie heuristic from the explicit OAuth login route
- stop adding `prompt=none` to user-initiated login requests
- keep silent authentication isolated to the dedicated silent-check route
- add a regression test for the complete generated authorization URL

## Root cause

The explicit login route inferred that a missing Obiente session cookie should start silent authentication. The Obiente cookie and the browser's ZITADEL session are separate states. With Login V2, `prompt=none` returns a raw `No active session found` response when no usable ZITADEL session can complete the request without interaction.

## Impact

An explicit login can reuse a valid ZITADEL session or display the interactive login interface. Users are no longer stranded on the raw ZITADEL error response when the browser only has stale or unusable session state.

## Validation

- `pnpm --filter @obiente/dashboard test` — 4 files, 10 tests passed
- `NUXT_SESSION_PASSWORD=local-validation-only-32-characters-minimum pnpm --filter @obiente/dashboard typecheck`
- scoped Prettier check
- `git diff --check`

The regression test verifies the authorization endpoint, callback URL, PKCE parameters, and absence of a `prompt` parameter.