### PR TITLE
fix(deployments): harden preview recovery after rollout

### DIFF
--- a/.github/workflows/reusable-container-build.yml
+++ b/.github/workflows/reusable-container-build.yml
@@ -134,7 +134,7 @@ jobs:
             ${{ inputs.commit-arg-prefix }}COMMIT=${{ github.sha }}
             ${{ inputs.commit-arg-prefix }}COMMIT_MESSAGE=${{ steps.commit.outputs.subject }}
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ matrix.architecture }}
-          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ matrix.architecture }},mode=max
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ matrix.architecture }},mode=max,ignore-error=true
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 

--- a/apps/deployments-service/internal/service/pull_request_deployments.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments.go
@@ -231,11 +231,12 @@ func (s *Service) reconcilePullRequestDeploymentConfig(ctx context.Context, sour
 	// this request or replica dies mid-reconciliation, the janitor will retry
 	// every runtime that was still attached instead of preserving the old
 	// policy for its previous (potentially very long) TTL.
-	now := time.Now()
-	if err := database.DB.WithContext(ctx).Model(&database.PullRequestDeployment{}).
-		Where("source_deployment_id = ? AND closed_at IS NULL AND preview_deployment_id IS NOT NULL", source.ID).
-		Updates(map[string]interface{}{"expires_at": now, "error": "Preview settings reconciliation is pending.", "updated_at": now}).Error; err != nil {
+	current, err := schedulePullRequestRuntimeReconciliation(ctx, config)
+	if err != nil {
 		return nil, fmt.Errorf("schedule durable settings reconciliation: %w", err)
+	}
+	if !current {
+		return nil, nil
 	}
 
 	integrationID, installationID := stringValue(source.GitHubIntegrationID), int64(0)
@@ -254,32 +255,46 @@ func (s *Service) reconcilePullRequestDeploymentConfig(ctx context.Context, sour
 	for i := range records {
 		record := records[i]
 		reconciled := false
+		superseded := false
 		lockKey := fmt.Sprintf("pull-request:%s:%s:%d", source.ID, record.Repository, record.PullRequestNumber)
-		if err := withDistributedLock(ctx, lockKey, func() error {
-			if err := database.DB.WithContext(ctx).Where("id = ? AND closed_at IS NULL", record.ID).First(&record).Error; err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
+		configLockKey := "pull-request-config:" + source.ID
+		if err := withDistributedLock(ctx, configLockKey, func() error {
+			return withDistributedLock(ctx, lockKey, func() error {
+				currentConfig, current, err := currentPullRequestReconciliationConfig(ctx, config)
+				if err != nil {
+					return err
+				}
+				if !current {
+					superseded = true
 					return nil
 				}
-				return err
-			}
-			if err := s.detachPullRequestRuntimeForReconciliation(ctx, &record, source, config.Enabled, integrationID, installationID); err != nil {
-				return err
-			}
-			if !config.Enabled {
-				s.reportPullRequestDeployment(record.ID)
+				if err := database.DB.WithContext(ctx).Where("id = ? AND closed_at IS NULL", record.ID).First(&record).Error; err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						return nil
+					}
+					return err
+				}
+				if err := s.detachPullRequestRuntimeForReconciliation(ctx, &record, source, currentConfig.Enabled, integrationID, installationID); err != nil {
+					return err
+				}
+				if !currentConfig.Enabled {
+					s.reportPullRequestDeployment(record.ID)
+					reconciled = true
+					return nil
+				}
+				payload := githubPullRequestWebhookPayload{Action: "reconcile", Number: record.PullRequestNumber}
+				payload.Installation.ID = installationID
+				payload.Repository.FullName = record.Repository
+				if err := s.processPullRequestWebhookLocked(ctx, *currentConfig, payload); err != nil {
+					return err
+				}
 				reconciled = true
 				return nil
-			}
-			payload := githubPullRequestWebhookPayload{Action: "reconcile", Number: record.PullRequestNumber}
-			payload.Installation.ID = installationID
-			payload.Repository.FullName = record.Repository
-			if err := s.processPullRequestWebhookLocked(ctx, *config, payload); err != nil {
-				return err
-			}
-			reconciled = true
-			return nil
+			})
 		}); err != nil {
 			reconciliationErrors = append(reconciliationErrors, fmt.Errorf("reconcile %s#%d: %w", record.Repository, record.PullRequestNumber, err))
+		} else if superseded {
+			return syncSource, nil
 		} else if reconciled {
 			processed[record.PullRequestNumber] = struct{}{}
 		}
@@ -290,6 +305,46 @@ func (s *Service) reconcilePullRequestDeploymentConfig(ctx context.Context, sour
 		}
 	}
 	return syncSource, errors.Join(reconciliationErrors...)
+}
+
+func schedulePullRequestRuntimeReconciliation(ctx context.Context, config *database.PullRequestDeploymentConfig) (bool, error) {
+	if config == nil {
+		return false, nil
+	}
+	current := false
+	err := withDistributedLock(ctx, "pull-request-config:"+config.DeploymentID, func() error {
+		currentConfig, isCurrent, err := currentPullRequestReconciliationConfig(ctx, config)
+		if err != nil || !isCurrent {
+			return err
+		}
+		now := time.Now()
+		result := database.DB.WithContext(ctx).Model(&database.PullRequestDeployment{}).
+			Where("source_deployment_id = ? AND closed_at IS NULL AND preview_deployment_id IS NOT NULL", currentConfig.DeploymentID).
+			Updates(map[string]interface{}{"expires_at": now, "error": "Preview settings reconciliation is pending.", "updated_at": now})
+		if result.Error != nil {
+			return result.Error
+		}
+		current = true
+		return nil
+	})
+	return current, err
+}
+
+func currentPullRequestReconciliationConfig(ctx context.Context, snapshot *database.PullRequestDeploymentConfig) (*database.PullRequestDeploymentConfig, bool, error) {
+	if snapshot == nil {
+		return nil, false, nil
+	}
+	var current database.PullRequestDeploymentConfig
+	err := database.DB.WithContext(ctx).
+		Where("deployment_id = ? AND reconciliation_pending = ? AND reconciliation_generation = ?", snapshot.DeploymentID, true, snapshot.ReconciliationGeneration).
+		First(&current).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return &current, true, nil
 }
 
 func loadPullRequestSyncSource(ctx context.Context, source *database.Deployment) (*pullRequestSyncSource, error) {

--- a/apps/deployments-service/internal/service/pull_request_deployments_test.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments_test.go
@@ -201,6 +201,56 @@ func TestStaleReconciliationCannotCompleteOrRescheduleNewGeneration(t *testing.T
 	}
 }
 
+func TestStaleReconciliationCannotDetachExistingRuntime(t *testing.T) {
+	db := newDeploymentServiceTestDB(t)
+	now := time.Now()
+	config := database.PullRequestDeploymentConfig{
+		DeploymentID: "source-runtime-generation", OrganizationID: "org", Enabled: true, ReconciliationPending: true,
+		ReconciliationGeneration: 2, BaseBranches: `[]`, IncludePaths: `[]`, ExcludePaths: `[]`,
+		EnvironmentVariableNames: `[]`, BuildArgumentNames: `[]`, DomainTemplate: defaultPRDomainTemplate,
+	}
+	previewID := "preview-runtime-generation"
+	record := database.PullRequestDeployment{
+		ID: "pr-runtime-generation", SourceDeploymentID: config.DeploymentID, PreviewDeploymentID: &previewID, OrganizationID: "org",
+		Repository: "obiente/cloud", PullRequestNumber: 7, HeadSHA: strings.Repeat("a", 40), HeadRef: "feature", BaseRef: "main",
+		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING), ExpiresAt: now.Add(time.Hour),
+	}
+	if err := db.Create(&config).Error; err != nil {
+		t.Fatalf("seed pull request config: %v", err)
+	}
+	if err := db.Create(&record).Error; err != nil {
+		t.Fatalf("seed pull request deployment: %v", err)
+	}
+
+	stale := config
+	stale.ReconciliationGeneration = 1
+	if current, err := schedulePullRequestRuntimeReconciliation(t.Context(), &stale); err != nil {
+		t.Fatalf("schedule stale runtime reconciliation: %v", err)
+	} else if current {
+		t.Fatal("stale settings generation was accepted for runtime reconciliation")
+	}
+	var unchanged database.PullRequestDeployment
+	if err := db.First(&unchanged, "id = ?", record.ID).Error; err != nil {
+		t.Fatalf("reload pull request deployment: %v", err)
+	}
+	if !unchanged.ExpiresAt.After(now) || unchanged.Error != nil {
+		t.Fatalf("stale settings generation detached the current runtime: %#v", unchanged)
+	}
+
+	if current, err := schedulePullRequestRuntimeReconciliation(t.Context(), &config); err != nil {
+		t.Fatalf("schedule current runtime reconciliation: %v", err)
+	} else if !current {
+		t.Fatal("current settings generation was rejected")
+	}
+	var scheduled database.PullRequestDeployment
+	if err := db.First(&scheduled, "id = ?", record.ID).Error; err != nil {
+		t.Fatalf("reload scheduled pull request deployment: %v", err)
+	}
+	if scheduled.ExpiresAt.After(time.Now()) || stringValue(scheduled.Error) != "Preview settings reconciliation is pending." {
+		t.Fatalf("current settings generation did not schedule runtime reconciliation: %#v", scheduled)
+	}
+}
+
 func TestOpenPullRequestSyncMarkerRequiresUnchangedSource(t *testing.T) {
 	db := newDeploymentServiceTestDB(t)
 	repository, replacement := "https://github.com/obiente/cloud", "https://github.com/obiente/website"
@@ -643,6 +693,28 @@ func TestPullRequestBooleanSettingsDoNotHaveORMDefaults(t *testing.T) {
 		}
 		if strings.Contains(field.Tag.Get("gorm"), "default:") {
 			t.Fatalf("%s has a GORM default that can override an explicitly supplied false value", name)
+		}
+	}
+}
+
+func TestPullRequestGitHubColumnsArePinned(t *testing.T) {
+	typeOfDeployment := reflect.TypeOf(database.PullRequestDeployment{})
+	wantColumns := map[string]string{
+		"GitHubIntegrationID":  "github_integration_id",
+		"GitHubInstallationID": "github_installation_id",
+		"GitHubDeploymentID":   "github_deployment_id",
+		"GitHubDeploymentSHA":  "github_deployment_sha",
+		"GitHubCommentID":      "github_comment_id",
+		"GitHubCheckRunID":     "github_check_run_id",
+		"GitHubCheckRunSHA":    "github_check_run_sha",
+	}
+	for fieldName, columnName := range wantColumns {
+		field, ok := typeOfDeployment.FieldByName(fieldName)
+		if !ok {
+			t.Fatalf("missing pull request deployment field %s", fieldName)
+		}
+		if !strings.Contains(field.Tag.Get("gorm"), "column:"+columnName) {
+			t.Fatalf("%s is not pinned to %s", fieldName, columnName)
 		}
 	}
 }

--- a/apps/shared/pkg/database/db.go
+++ b/apps/shared/pkg/database/db.go
@@ -615,13 +615,51 @@ func InitDatabase() error {
 
 func ensurePullRequestPreviewCompatibilityColumns(db *gorm.DB) error {
 	statements := []string{
-		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS ignored_head_sha TEXT`,
-		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS active_head_sha TEXT`,
+		// GORM previously named these fields git_hub_*. Add the canonical columns
+		// nullable first so installations with existing previews can retain their
+		// GitHub identity and reporting records before non-null constraints apply.
+		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_integration_id TEXT`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_installation_id BIGINT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_deployment_id BIGINT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_deployment_sha TEXT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_comment_id BIGINT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_check_run_id BIGINT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS github_check_run_sha TEXT`,
+		`DO $$
+		 DECLARE
+		   column_mapping RECORD;
+		 BEGIN
+		   IF to_regclass('pull_request_deployments') IS NOT NULL THEN
+		     FOR column_mapping IN
+		       SELECT * FROM (VALUES
+		         ('git_hub_integration_id', 'github_integration_id'),
+		         ('git_hub_installation_id', 'github_installation_id'),
+		         ('git_hub_deployment_id', 'github_deployment_id'),
+		         ('git_hub_deployment_sha', 'github_deployment_sha'),
+		         ('git_hub_comment_id', 'github_comment_id'),
+		         ('git_hub_check_run_id', 'github_check_run_id'),
+		         ('git_hub_check_run_sha', 'github_check_run_sha')
+		       ) AS mapping(legacy_name, canonical_name)
+		     LOOP
+		       IF EXISTS (
+		         SELECT 1 FROM information_schema.columns
+		         WHERE table_schema = current_schema()
+		           AND table_name = 'pull_request_deployments'
+		           AND column_name = column_mapping.legacy_name
+		       ) THEN
+		         EXECUTE format(
+		           'UPDATE pull_request_deployments SET %1$I = %2$I WHERE %1$I IS NULL AND %2$I IS NOT NULL',
+		           column_mapping.canonical_name,
+		           column_mapping.legacy_name
+		         );
+		       END IF;
+		     END LOOP;
+		   END IF;
+		 END $$`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ALTER COLUMN github_integration_id SET NOT NULL`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ALTER COLUMN github_installation_id SET NOT NULL`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS ignored_head_sha TEXT`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS active_head_sha TEXT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS report_pending BOOLEAN NOT NULL DEFAULT FALSE`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS report_attempts INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS next_report_at TIMESTAMPTZ`,

--- a/apps/shared/pkg/database/models.go
+++ b/apps/shared/pkg/database/models.go
@@ -108,8 +108,8 @@ type PullRequestDeployment struct {
 	SourceDeploymentID   string     `gorm:"not null;uniqueIndex:idx_pr_deployment_source_repo_number" json:"source_deployment_id"`
 	PreviewDeploymentID  *string    `gorm:"uniqueIndex" json:"preview_deployment_id"`
 	OrganizationID       string     `gorm:"index;not null" json:"organization_id"`
-	GitHubIntegrationID  string     `gorm:"index;not null" json:"github_integration_id"`
-	GitHubInstallationID int64      `gorm:"index;not null" json:"github_installation_id"`
+	GitHubIntegrationID  string     `gorm:"column:github_integration_id;index;not null" json:"github_integration_id"`
+	GitHubInstallationID int64      `gorm:"column:github_installation_id;index;not null" json:"github_installation_id"`
 	Repository           string     `gorm:"not null;uniqueIndex:idx_pr_deployment_source_repo_number" json:"repository"`
 	PullRequestNumber    int64      `gorm:"not null;uniqueIndex:idx_pr_deployment_source_repo_number" json:"pull_request_number"`
 	HeadSHA              string     `gorm:"index;not null" json:"head_sha"`
@@ -124,11 +124,11 @@ type PullRequestDeployment struct {
 	IsolationVersion     int32      `gorm:"index;not null;default:0" json:"isolation_version"`
 	EnvironmentURL       *string    `json:"environment_url"`
 	Error                *string    `gorm:"type:text" json:"error"`
-	GitHubDeploymentID   *int64     `json:"github_deployment_id"`
-	GitHubDeploymentSHA  *string    `json:"github_deployment_sha"`
-	GitHubCommentID      *int64     `json:"github_comment_id"`
-	GitHubCheckRunID     *int64     `json:"github_check_run_id"`
-	GitHubCheckRunSHA    *string    `json:"github_check_run_sha"`
+	GitHubDeploymentID   *int64     `gorm:"column:github_deployment_id" json:"github_deployment_id"`
+	GitHubDeploymentSHA  *string    `gorm:"column:github_deployment_sha" json:"github_deployment_sha"`
+	GitHubCommentID      *int64     `gorm:"column:github_comment_id" json:"github_comment_id"`
+	GitHubCheckRunID     *int64     `gorm:"column:github_check_run_id" json:"github_check_run_id"`
+	GitHubCheckRunSHA    *string    `gorm:"column:github_check_run_sha" json:"github_check_run_sha"`
 	ReportPending        bool       `gorm:"index;not null;default:false" json:"report_pending"`
 	ReportAttempts       int32      `gorm:"not null;default:0" json:"report_attempts"`
 	NextReportAt         *time.Time `gorm:"index" json:"next_report_at"`

--- a/apps/shared/pkg/orchestrator/deployment_manager_config.go
+++ b/apps/shared/pkg/orchestrator/deployment_manager_config.go
@@ -547,55 +547,6 @@ func (dm *DeploymentManager) injectTraefikLabelsIntoCompose(composeYaml string, 
 		}
 	}
 
-	// Ensure network configuration is set correctly for Swarm mode
-	// In Swarm mode, services must be on the network that Traefik monitors
-	if isSwarmMode {
-		// Ensure networks section exists
-		var networks map[string]interface{}
-		if existingNetworks, ok := compose["networks"].(map[string]interface{}); ok {
-			networks = existingNetworks
-		} else {
-			networks = make(map[string]interface{})
-			compose["networks"] = networks
-		}
-
-		// Add or update obiente-network to be external (references the Swarm network)
-		// In Swarm mode, the network name is prefixed with stack name: {stack-name}_obiente-network
-		networkConfig := map[string]interface{}{
-			"external": true,
-			"name":     ingressNetworkName,
-		}
-		networks["obiente-network"] = networkConfig
-
-		// Ensure all services are connected to the network
-		if services, ok := compose["services"].(map[string]interface{}); ok {
-			for serviceName, serviceData := range services {
-				if service, ok := serviceData.(map[string]interface{}); ok {
-					routed := false
-					for _, routing := range routings {
-						if routing.ServiceName == serviceName || ((routing.ServiceName == "" || routing.ServiceName == "default") && serviceName == "default") {
-							routed = true
-							break
-						}
-					}
-					if !routed {
-						continue
-					}
-					serviceNetworks := normalizeServiceNetworks(service)
-
-					// Ensure obiente-network is in the service's networks and every network has the bare service alias.
-					serviceNetworks["obiente-network"] = mergeNetworkAliases(serviceNetworks["obiente-network"], serviceName)
-					for networkName, networkConfig := range serviceNetworks {
-						serviceNetworks[networkName] = mergeNetworkAliases(networkConfig, serviceName)
-					}
-
-					service["networks"] = serviceNetworks
-					logger.Debug("[DeploymentManager] Ensured service %s is connected to obiente-network (Swarm mode)", serviceName)
-				}
-			}
-		}
-	}
-
 	// Marshal back to YAML
 	labeledYaml, err := yaml.Marshal(compose)
 	if err != nil {

--- a/apps/shared/pkg/orchestrator/deployment_manager_config_test.go
+++ b/apps/shared/pkg/orchestrator/deployment_manager_config_test.go
@@ -215,7 +215,12 @@ networks:
     external: true
 `)
 
-	gotYaml, err := dm.addTraefikNetworkToRoutedServices(composeYaml, []database.DeploymentRouting{{ServiceName: "web"}}, ingressNetwork)
+	routings := []database.DeploymentRouting{{ServiceName: "web", Domain: "preview.example.com", TargetPort: 3000}}
+	labeledYaml, err := dm.injectTraefikLabelsIntoCompose(composeYaml, "preview-123", routings, ingressNetwork)
+	if err != nil {
+		t.Fatalf("injectTraefikLabelsIntoCompose failed: %v", err)
+	}
+	gotYaml, err := dm.addTraefikNetworkToRoutedServices(labeledYaml, routings, ingressNetwork)
 	if err != nil {
 		t.Fatalf("addTraefikNetworkToRoutedServices failed: %v", err)
 	}

--- a/apps/shared/pkg/orchestrator/deployment_manager_container_test.go
+++ b/apps/shared/pkg/orchestrator/deployment_manager_container_test.go
@@ -1,12 +1,45 @@
 package orchestrator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestSwarmIngressProxyServiceNameUsesCurrentStack(t *testing.T) {
+	t.Setenv("TRAEFIK_SERVICE_NAME", "")
+	t.Setenv("STACK_NAME", "obiente-dev")
+
+	serviceName, err := swarmIngressProxyServiceName(context.Background())
+	if err != nil {
+		t.Fatalf("resolve ingress proxy service: %v", err)
+	}
+	if serviceName != "obiente-dev_traefik" {
+		t.Fatalf("ingress proxy service = %q, want obiente-dev_traefik", serviceName)
+	}
+}
+
+func TestSwarmIngressProxyServiceNameHonorsExplicitOverride(t *testing.T) {
+	t.Setenv("TRAEFIK_SERVICE_NAME", "custom-edge")
+	t.Setenv("STACK_NAME", "obiente-dev")
+
+	serviceName, err := swarmIngressProxyServiceName(context.Background())
+	if err != nil {
+		t.Fatalf("resolve ingress proxy service: %v", err)
+	}
+	if serviceName != "custom-edge" {
+		t.Fatalf("ingress proxy service = %q, want custom-edge", serviceName)
+	}
+}
+
+func TestDockerNetworkMissingRecognizesDockerInspectMessage(t *testing.T) {
+	if !dockerNetworkMissing("Error response from daemon: network preview-123 not found") {
+		t.Fatal("expected Docker's inspect error to be treated as an already removed network")
+	}
+}
 
 func TestSwarmServiceNetworkUpdateRemovesInspectedLegacyAttachments(t *testing.T) {
 	t.Parallel()

--- a/apps/shared/pkg/orchestrator/deployment_manager_network.go
+++ b/apps/shared/pkg/orchestrator/deployment_manager_network.go
@@ -7,13 +7,18 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/obiente/cloud/apps/shared/pkg/database"
 	"github.com/obiente/cloud/apps/shared/pkg/logger"
 	"github.com/obiente/cloud/apps/shared/pkg/utils"
+	"gorm.io/gorm"
 )
 
 // Network operations for deployments
+
+var ingressProxyMutationLocks sync.Map
 
 func (dm *DeploymentManager) getSwarmNetworkName(ctx context.Context) (string, error) {
 	// Try multiple approaches to find the network
@@ -241,24 +246,15 @@ func ensureSwarmIngressProxyNetwork(ctx context.Context, networkName string) err
 	if err != nil {
 		return err
 	}
-	existingNetworks, err := existingSwarmServiceNetworkNames(ctx, serviceName)
-	if err != nil {
-		return fmt.Errorf("inspect ingress proxy service %s: %w", serviceName, err)
-	}
-	if containsString(existingNetworks, networkName) {
-		return nil
-	}
-	command := exec.CommandContext(ctx, "docker", "service", "update", "--network-add", networkName, serviceName)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("attach ingress proxy service %s to %s: %w (%s)", serviceName, networkName, err, strings.TrimSpace(string(output)))
-	}
-	return nil
+	return mutateSwarmIngressProxyNetwork(ctx, serviceName, networkName, true)
 }
 
 func swarmIngressProxyServiceName(ctx context.Context) (string, error) {
 	if serviceName := strings.TrimSpace(os.Getenv("TRAEFIK_SERVICE_NAME")); serviceName != "" {
 		return serviceName, nil
+	}
+	if stackName := strings.TrimSpace(os.Getenv("STACK_NAME")); stackName != "" {
+		return stackName + "_traefik", nil
 	}
 	command := exec.CommandContext(ctx, "docker", "service", "ls", "--filter", "label=cloud.obiente.ingress-proxy=true", "--format", "{{.Name}}")
 	if output, err := command.Output(); err == nil {
@@ -273,11 +269,7 @@ func swarmIngressProxyServiceName(ctx context.Context) (string, error) {
 			return "", fmt.Errorf("multiple ingress proxy services matched cloud.obiente.ingress-proxy=true")
 		}
 	}
-	stackName := strings.TrimSpace(os.Getenv("STACK_NAME"))
-	if stackName == "" {
-		stackName = "obiente"
-	}
-	return stackName + "_traefik", nil
+	return "", fmt.Errorf("ingress proxy service is ambiguous; configure STACK_NAME or TRAEFIK_SERVICE_NAME")
 }
 
 func ensureContainerIngressProxyNetwork(ctx context.Context, networkName string) error {
@@ -355,19 +347,61 @@ func removeSwarmIngressProxyNetwork(ctx context.Context, networkName string) err
 	if err != nil {
 		return err
 	}
-	existingNetworks, err := existingSwarmServiceNetworkNames(ctx, serviceName)
-	if err != nil {
-		return fmt.Errorf("inspect ingress proxy service %s: %w", serviceName, err)
+	return mutateSwarmIngressProxyNetwork(ctx, serviceName, networkName, false)
+}
+
+func mutateSwarmIngressProxyNetwork(ctx context.Context, serviceName, networkName string, attach bool) error {
+	return withIngressProxyMutationLock(ctx, serviceName, func() error {
+		var lastErr error
+		var lastOutput string
+		for attempt := 0; attempt < 4; attempt++ {
+			existingNetworks, err := existingSwarmServiceNetworkNames(ctx, serviceName)
+			if err != nil {
+				lastErr = fmt.Errorf("inspect ingress proxy service %s: %w", serviceName, err)
+			} else {
+				currentlyAttached := containsString(existingNetworks, networkName)
+				if currentlyAttached == attach {
+					return nil
+				}
+				operation := "--network-rm"
+				if attach {
+					operation = "--network-add"
+				}
+				command := exec.CommandContext(ctx, "docker", "service", "update", operation, networkName, serviceName)
+				output, updateErr := command.CombinedOutput()
+				lastOutput = strings.TrimSpace(string(output))
+				if updateErr == nil {
+					return nil
+				}
+				lastErr = updateErr
+			}
+			if err := waitForPreviewNetworkRetry(ctx, 250*time.Millisecond); err != nil {
+				return err
+			}
+		}
+		action := "detach from"
+		if attach {
+			action = "attach to"
+		}
+		return fmt.Errorf("%s ingress proxy service %s network %s: %w (%s)", action, serviceName, networkName, lastErr, lastOutput)
+	})
+}
+
+func withIngressProxyMutationLock(ctx context.Context, serviceName string, fn func() error) error {
+	value, _ := ingressProxyMutationLocks.LoadOrStore(serviceName, &sync.Mutex{})
+	mutex := value.(*sync.Mutex)
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if database.DB != nil && database.DB.Dialector.Name() == "postgres" {
+		return database.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec("SELECT pg_advisory_xact_lock(hashtextextended(?, 0))", "ingress-proxy-network:"+serviceName).Error; err != nil {
+				return err
+			}
+			return fn()
+		})
 	}
-	if !containsString(existingNetworks, networkName) {
-		return nil
-	}
-	command := exec.CommandContext(ctx, "docker", "service", "update", "--network-rm", networkName, serviceName)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("detach ingress proxy service %s from %s: %w (%s)", serviceName, networkName, err, strings.TrimSpace(string(output)))
-	}
-	return nil
+	return fn()
 }
 
 func removeContainerIngressProxyNetwork(ctx context.Context, networkName string) error {
@@ -389,7 +423,9 @@ func removeContainerIngressProxyNetwork(ctx context.Context, networkName string)
 
 func dockerNetworkMissing(output string) bool {
 	output = strings.ToLower(output)
-	return strings.Contains(output, "no such network") || strings.Contains(output, "network not found")
+	return strings.Contains(output, "no such network") ||
+		strings.Contains(output, "network not found") ||
+		(strings.Contains(output, "network ") && strings.Contains(output, " not found"))
 }
 
 func waitForPreviewNetworkRetry(ctx context.Context, delay time.Duration) error {

--- a/docker-compose.swarm.dev.yml
+++ b/docker-compose.swarm.dev.yml
@@ -416,6 +416,7 @@ services:
       dockerfile: apps/deployments-service/Dockerfile
     environment:
       PORT: 3005
+      STACK_NAME: __STACK_NAME__
       DEPLOYMENTS_INTERNAL_SERVICE_SECRET: ${DEPLOYMENTS_INTERNAL_SERVICE_SECRET:-}
       PREVIEW_STATUS_BASE_URL: ${PREVIEW_STATUS_BASE_URL:-}
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis, *common-github, *common-orchestrator, *common-dns-delegation, *common-notifications, *common-dashboard]
@@ -1057,7 +1058,9 @@ services:
       mode: global  # Run one instance on each manager node
       update_config:
         parallelism: 1
-        order: start-first
+        # Host-published ports cannot be held by old and replacement tasks on
+        # the same node at once.
+        order: stop-first
       placement:
         constraints:
           - node.role == manager  # Only run on manager nodes

--- a/docker-compose.swarm.ha.yml
+++ b/docker-compose.swarm.ha.yml
@@ -506,7 +506,9 @@ services:
       mode: global  # Run on all nodes for HA and DNS to resolve properly
       update_config:
         parallelism: 1
-        order: start-first
+        # Host-published ports cannot be held by old and replacement tasks on
+        # the same node at once.
+        order: stop-first
       placement:
         constraints:
           - node.labels.traefik.exclude != true  # Exclude nodes labeled with traefik.exclude=true
@@ -907,6 +909,7 @@ services:
     image: ghcr.io/obiente/cloud-deployments-service:latest
     environment:
       PORT: 3005
+      STACK_NAME: __STACK_NAME__
       DEPLOYMENTS_INTERNAL_SERVICE_SECRET: ${DEPLOYMENTS_INTERNAL_SERVICE_SECRET:-}
       PREVIEW_STATUS_BASE_URL: ${PREVIEW_STATUS_BASE_URL:-}
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis, *common-github, *common-orchestrator, *common-dns-delegation, *common-notifications, *common-dashboard]

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -416,6 +416,7 @@ services:
     image: ghcr.io/obiente/cloud-deployments-service:latest
     environment:
       PORT: 3005
+      STACK_NAME: __STACK_NAME__
       DEPLOYMENTS_INTERNAL_SERVICE_SECRET: ${DEPLOYMENTS_INTERNAL_SERVICE_SECRET:-}
       PREVIEW_STATUS_BASE_URL: ${PREVIEW_STATUS_BASE_URL:-}
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis, *common-github, *common-swarm-orchestrator, *common-dns-delegation, *common-notifications, *common-dashboard]
@@ -1064,7 +1065,9 @@ services:
       mode: global  # Run one instance on each manager node
       update_config:
         parallelism: 1
-        order: start-first
+        # Host-published ports cannot be held by old and replacement tasks on
+        # the same node at once.
+        order: stop-first
       placement:
         constraints:
           - node.role == manager  # Only run on manager nodes


### PR DESCRIPTION
## Summary

- prevent superseded pull request configuration generations from detaching or rebuilding previews with stale policy
- serialize Traefik network mutations across replicas and target the ingress proxy belonging to the current stack
- reuse the selected deployment network instead of injecting a duplicate Compose network
- migrate legacy `git_hub_*` preview identity fields into pinned `github_*` columns before serving traffic
- make already-removed preview networks safe to clean up repeatedly
- keep successful image publishes green when the optional registry cache is temporarily unavailable
- use stop-first Traefik updates because host-published ports cannot be shared by replacement tasks on the same node

## Root cause

The rollout from #33 exposed three compatibility assumptions: older preview rows used GORM's legacy GitHub column names, concurrent preview operations could update the same Swarm ingress service without shared serialization, and host-mode Traefik tasks were updated start-first. The latest review also found that an older reconciliation worker could continue after a newer settings generation had replaced it and that Compose label injection created a network before the later reuse pass could select the existing deployment network.

## Impact

Existing pull request previews retain their GitHub installation, deployment, check, and maintained-comment identities during automatic migration. Reconciliation now stops when its generation is superseded, concurrent network changes converge safely, and multi-stack installations do not mutate another stack's Traefik service. Temporary build-cache outages no longer turn a successfully published image into a failed workflow.

## Validation

- `gofmt` applied to all changed Go files
- `git diff --check`
- read-only production schema audit confirmed existing preview identities can be migrated from the legacy columns
- exact-head builds and tests are delegated to GitHub Actions

Follow-up to #33.
