### PR TITLE
fix(deployments): provision preview wildcard TLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,13 @@ ACME_EMAIL=admin@obiente.cloud
 # Use any provider supported by lego and store its credentials in the
 # preview_dns_credentials Docker secret. See docs/deployment/docker-swarm.md.
 PREVIEW_ACME_DNS_PROVIDER=
+# Required when the bundled DNS service is authoritative for my.obiente.cloud.
+# Point outside that delegated zone to a name controlled by the selected provider.
+PREVIEW_ACME_CHALLENGE_CNAME=
+# HA stacks load an externally issued wildcard certificate from versioned
+# Swarm secrets. Change these names during certificate rotation.
+PREVIEW_TLS_CERT_SECRET=preview_tls_cert
+PREVIEW_TLS_KEY_SECRET=preview_tls_key
 
 # =============================================================================
 # Security

--- a/.env.example
+++ b/.env.example
@@ -63,15 +63,11 @@ CORS_ORIGIN=*
 DOMAIN=obiente.cloud
 ACME_EMAIL=admin@obiente.cloud
 # Required for Let's Encrypt SSL certificate generation
-# DNS-01 provider code used for the wildcard PR preview certificate.
-# Use any provider supported by lego and store its credentials in the
-# preview_dns_credentials Docker secret. See docs/deployment/docker-swarm.md.
-PREVIEW_ACME_DNS_PROVIDER=
-# Required when the bundled DNS service is authoritative for my.obiente.cloud.
-# Point outside that delegated zone to a name controlled by the selected provider.
+# Optional DNS-01 delegation for external wildcard certificate issuance when
+# the bundled DNS service is authoritative for my.obiente.cloud.
 PREVIEW_ACME_CHALLENGE_CNAME=
-# HA stacks load an externally issued wildcard certificate from versioned
-# Swarm secrets. Change these names during certificate rotation.
+# All Swarm stacks load the wildcard certificate from versioned Swarm secrets.
+# Change these names during certificate rotation.
 PREVIEW_TLS_CERT_SECRET=preview_tls_cert
 PREVIEW_TLS_KEY_SECRET=preview_tls_key
 

--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ CORS_ORIGIN=*
 DOMAIN=obiente.cloud
 ACME_EMAIL=admin@obiente.cloud
 # Required for Let's Encrypt SSL certificate generation
+# DNS-01 provider code used for the wildcard PR preview certificate.
+# Use any provider supported by lego and store its credentials in the
+# preview_dns_credentials Docker secret. See docs/deployment/docker-swarm.md.
+PREVIEW_ACME_DNS_PROVIDER=
 
 # =============================================================================
 # Security

--- a/apps/deployments-service/internal/service/pull_request_deployments.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments.go
@@ -36,9 +36,9 @@ const (
 	maxPRFilterCount          = 100
 	maxPRFilterLength         = 256
 	prEnvironmentCommentMark  = "<!-- obiente-pr-environment:%s -->"
-	// Version 4 provisions durable routes and fully reconciled provider-specific
-	// Traefik labels for every preview build strategy before deployment.
-	currentPRIsolationVersion = int32(4)
+	// Version 5 provisions durable routes that use the platform wildcard
+	// certificate and fully reconciled provider-specific Traefik labels.
+	currentPRIsolationVersion = int32(5)
 	pendingPRIsolationVersion = int32(-1)
 )
 
@@ -1268,12 +1268,9 @@ func previewSingleServiceRouting(preview, source *database.Deployment, sourceRou
 	}
 	template := preferredPreviewSourceRouting(source, sourceRoutings)
 	targetPort := 0
-	certResolver, middleware, pathPrefix := "letsencrypt", "{}", ""
+	middleware, pathPrefix := "{}", ""
 	if template != nil {
 		targetPort = template.TargetPort
-		if strings.TrimSpace(template.SSLCertResolver) != "" && template.SSLCertResolver != "internal" {
-			certResolver = template.SSLCertResolver
-		}
 		if strings.TrimSpace(template.Middleware) != "" {
 			middleware = template.Middleware
 		}
@@ -1286,15 +1283,17 @@ func previewSingleServiceRouting(preview, source *database.Deployment, sourceRou
 	}
 	now := time.Now()
 	return &database.DeploymentRouting{
-		ID:              fmt.Sprintf("route-%s-default", preview.ID),
-		DeploymentID:    preview.ID,
-		Domain:          preview.Domain,
-		ServiceName:     "default",
-		PathPrefix:      pathPrefix,
-		TargetPort:      targetPort,
-		Protocol:        "https",
-		SSLEnabled:      true,
-		SSLCertResolver: certResolver,
+		ID:           fmt.Sprintf("route-%s-default", preview.ID),
+		DeploymentID: preview.ID,
+		Domain:       preview.Domain,
+		ServiceName:  "default",
+		PathPrefix:   pathPrefix,
+		TargetPort:   targetPort,
+		Protocol:     "https",
+		SSLEnabled:   true,
+		// Preview hosts are covered by the platform wildcard certificate. Leaving
+		// the resolver empty prevents one ACME order for every pull request.
+		SSLCertResolver: "",
 		Middleware:      middleware,
 		CreatedAt:       now,
 		UpdatedAt:       now,
@@ -1309,15 +1308,12 @@ func previewComposeRouting(preview, source *database.Deployment, sourceRoutings 
 	template := preferredPreviewSourceRouting(source, sourceRoutings)
 
 	targetPort := 0
-	serviceName, certResolver, middleware := "default", "letsencrypt", "{}"
+	serviceName, middleware := "default", "{}"
 	pathPrefix := ""
 	if template != nil {
 		targetPort = template.TargetPort
 		if strings.TrimSpace(template.ServiceName) != "" {
 			serviceName = template.ServiceName
-		}
-		if strings.TrimSpace(template.SSLCertResolver) != "" && template.SSLCertResolver != "internal" {
-			certResolver = template.SSLCertResolver
 		}
 		if strings.TrimSpace(template.Middleware) != "" {
 			middleware = template.Middleware
@@ -1339,15 +1335,17 @@ func previewComposeRouting(preview, source *database.Deployment, sourceRoutings 
 
 	now := time.Now()
 	return &database.DeploymentRouting{
-		ID:              fmt.Sprintf("route-%s-default", preview.ID),
-		DeploymentID:    preview.ID,
-		Domain:          preview.Domain,
-		ServiceName:     serviceName,
-		PathPrefix:      pathPrefix,
-		TargetPort:      targetPort,
-		Protocol:        "https",
-		SSLEnabled:      true,
-		SSLCertResolver: certResolver,
+		ID:           fmt.Sprintf("route-%s-default", preview.ID),
+		DeploymentID: preview.ID,
+		Domain:       preview.Domain,
+		ServiceName:  serviceName,
+		PathPrefix:   pathPrefix,
+		TargetPort:   targetPort,
+		Protocol:     "https",
+		SSLEnabled:   true,
+		// Preview hosts are covered by the platform wildcard certificate. Leaving
+		// the resolver empty prevents one ACME order for every pull request.
+		SSLCertResolver: "",
 		Middleware:      middleware,
 		CreatedAt:       now,
 		UpdatedAt:       now,

--- a/apps/deployments-service/internal/service/pull_request_deployments_test.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments_test.go
@@ -598,8 +598,8 @@ func TestPreviewComposeRoutingUsesPreviewDomainAndSourceService(t *testing.T) {
 	if routing.DeploymentID != preview.ID || routing.Domain != preview.Domain || routing.ServiceName != "web" || routing.TargetPort != 8080 {
 		t.Fatalf("unexpected preview routing: %#v", routing)
 	}
-	if !routing.SSLEnabled || routing.SSLCertResolver != "letsencrypt" {
-		t.Fatalf("preview routing does not enable managed HTTPS: %#v", routing)
+	if !routing.SSLEnabled || routing.SSLCertResolver != "" {
+		t.Fatalf("preview routing does not rely on platform wildcard HTTPS: %#v", routing)
 	}
 	if routing.Protocol != "https" {
 		t.Fatalf("preview routing does not use the HTTPS entrypoint: %#v", routing)
@@ -628,6 +628,9 @@ func TestPreviewDockerfileRoutingUsesPreviewDomainAndSourcePort(t *testing.T) {
 	}
 	if routing.PathPrefix != "/docs" || routing.Protocol != "https" || !routing.SSLEnabled {
 		t.Fatalf("Dockerfile preview routing did not preserve the public route: %#v", routing)
+	}
+	if routing.SSLCertResolver != "" {
+		t.Fatalf("Dockerfile preview requested a per-PR certificate: %#v", routing)
 	}
 }
 

--- a/apps/dns-service/Dockerfile
+++ b/apps/dns-service/Dockerfile
@@ -26,6 +26,7 @@ RUN cd apps/shared && GOWORK=off go mod download && \
 RUN --mount=type=bind,source=.,target=/src,rw \
     --mount=type=cache,target=/root/.cache/go-build \
     cd /src/apps/dns-service && \
+    GOWORK=off go test ./... && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     GOWORK=off go build -trimpath -ldflags="-w -s -extldflags '-static'" \
     -o /build/dns-service .

--- a/apps/dns-service/README.md
+++ b/apps/dns-service/README.md
@@ -24,6 +24,8 @@ See shared configuration in `docker-compose.yml` for common variables.
 - `DNS_IPS` - DNS server IP addresses (optional, for documentation)
 - `DNS_PORT` - DNS server port (default: 53)
 - `REDIS_URL` - Redis connection URL (for caching)
+- `PREVIEW_ACME_CHALLENGE_CNAME` - Provider-managed DNS name outside
+  `my.obiente.cloud` used for wildcard certificate DNS-01 validation
 
 ## Endpoints
 
@@ -40,4 +42,3 @@ See shared configuration in `docker-compose.yml` for common variables.
 - Requires `NET_BIND_SERVICE` capability to bind to port 53
 - Must be accessible on port 53 for DNS queries
 - Caches DNS responses for 60 seconds
-

--- a/apps/dns-service/main.go
+++ b/apps/dns-service/main.go
@@ -27,15 +27,18 @@ import (
 const (
 	cacheTTL                  = 5 * time.Minute // Cache DNS responses for 5 minutes
 	defaultGameServerDNSGrace = 2 * time.Minute // Keep stale game server DNS briefly after stop
+	previewACMEChallengeName  = "_acme-challenge.my.obiente.cloud."
+	previewACMECNAMETTL       = 60
 	httpReadHeaderTimeout     = 10 * time.Second
 	serviceShutdownTimeout    = 30 * time.Second
 )
 
 type DNSServer struct {
-	db                       *gorm.DB
-	nodeIPMap                map[string][]string
-	redisCache               *database.RedisCache
-	gameServerStaleGraceTime time.Duration
+	db                        *gorm.DB
+	nodeIPMap                 map[string][]string
+	redisCache                *database.RedisCache
+	gameServerStaleGraceTime  time.Duration
+	previewACMEChallengeCNAME string
 }
 
 func NewDNSServer() (*DNSServer, error) {
@@ -137,7 +140,30 @@ func NewDNSServer() (*DNSServer, error) {
 	}
 	log.Printf("[DNS] Game server DNS stale grace configured to %s", s.gameServerStaleGraceTime)
 
+	challengeTarget, err := normalizePreviewACMEChallengeCNAME(os.Getenv("PREVIEW_ACME_CHALLENGE_CNAME"))
+	if err != nil {
+		return nil, err
+	}
+	if challengeTarget != "" {
+		s.previewACMEChallengeCNAME = challengeTarget
+		log.Printf("[DNS] Preview ACME challenge delegated to %s", challengeTarget)
+	}
+
 	return s, nil
+}
+
+func normalizePreviewACMEChallengeCNAME(value string) (string, error) {
+	target := dns.Fqdn(strings.ToLower(strings.TrimSpace(value)))
+	if target == "." {
+		return "", nil
+	}
+	if _, ok := dns.IsDomainName(target); !ok {
+		return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must be a valid DNS name")
+	}
+	if target == previewACMEChallengeName || strings.HasSuffix(target, ".my.obiente.cloud.") {
+		return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must point outside the delegated my.obiente.cloud zone")
+	}
+	return target, nil
 }
 
 func (s *DNSServer) getCached(ctx context.Context, deploymentID string) ([]string, bool) {
@@ -203,6 +229,14 @@ func (s *DNSServer) handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
 			return
 		}
 
+		// The preview wildcard is issued through a provider-managed challenge
+		// name outside this delegated zone. A CNAME is returned for every query
+		// type so recursive resolvers can follow it when looking up the TXT value.
+		if s.handlePreviewACMEChallenge(msg, q) {
+			w.WriteMsg(msg)
+			return
+		}
+
 		// Handle SRV record queries for game servers
 		// Format: _minecraft._tcp.gs-123.my.obiente.cloud
 		// Format: _minecraft._udp.gs-123.my.obiente.cloud (Bedrock)
@@ -233,6 +267,23 @@ func (s *DNSServer) handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	w.WriteMsg(msg)
+}
+
+func (s *DNSServer) handlePreviewACMEChallenge(msg *dns.Msg, q dns.Question) bool {
+	if s.previewACMEChallengeCNAME == "" || !strings.EqualFold(dns.Fqdn(q.Name), previewACMEChallengeName) {
+		return false
+	}
+
+	msg.Answer = append(msg.Answer, &dns.CNAME{
+		Hdr: dns.RR_Header{
+			Name:   previewACMEChallengeName,
+			Rrtype: dns.TypeCNAME,
+			Class:  dns.ClassINET,
+			Ttl:    previewACMECNAMETTL,
+		},
+		Target: s.previewACMEChallengeCNAME,
+	})
+	return true
 }
 
 // handleSRVQuery handles SRV record queries for game servers

--- a/apps/dns-service/main.go
+++ b/apps/dns-service/main.go
@@ -27,6 +27,7 @@ import (
 const (
 	cacheTTL                  = 5 * time.Minute // Cache DNS responses for 5 minutes
 	defaultGameServerDNSGrace = 2 * time.Minute // Keep stale game server DNS briefly after stop
+	previewDNSZoneName        = "my.obiente.cloud."
 	previewACMEChallengeName  = "_acme-challenge.my.obiente.cloud."
 	previewACMECNAMETTL       = 60
 	httpReadHeaderTimeout     = 10 * time.Second
@@ -165,7 +166,7 @@ func normalizePreviewACMEChallengeCNAME(value string) (string, error) {
 			return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must contain only valid ASCII DNS labels")
 		}
 	}
-	if target == previewACMEChallengeName || strings.HasSuffix(target, ".my.obiente.cloud.") {
+	if target == previewDNSZoneName || strings.HasSuffix(target, "."+previewDNSZoneName) {
 		return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must point outside the delegated my.obiente.cloud zone")
 	}
 	return target, nil

--- a/apps/dns-service/main.go
+++ b/apps/dns-service/main.go
@@ -160,10 +160,28 @@ func normalizePreviewACMEChallengeCNAME(value string) (string, error) {
 	if _, ok := dns.IsDomainName(target); !ok {
 		return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must be a valid DNS name")
 	}
+	for _, label := range dns.SplitDomainName(target) {
+		if !validPreviewACMEDNSLabel(label) {
+			return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must contain only valid ASCII DNS labels")
+		}
+	}
 	if target == previewACMEChallengeName || strings.HasSuffix(target, ".my.obiente.cloud.") {
 		return "", fmt.Errorf("PREVIEW_ACME_CHALLENGE_CNAME must point outside the delegated my.obiente.cloud zone")
 	}
 	return target, nil
+}
+
+func validPreviewACMEDNSLabel(label string) bool {
+	if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+		return false
+	}
+	for _, char := range label {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '-' || char == '_' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func (s *DNSServer) getCached(ctx context.Context, deploymentID string) ([]string, bool) {

--- a/apps/dns-service/main_test.go
+++ b/apps/dns-service/main_test.go
@@ -22,6 +22,9 @@ func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
 		"_acme-challenge.my.obiente.cloud",
 		"nested.my.obiente.cloud",
 		"invalid name",
+		"-invalid.example.net",
+		"invalid-.example.net",
+		"täst.example.net",
 	} {
 		_, err := normalizePreviewACMEChallengeCNAME(value)
 		if err == nil {

--- a/apps/dns-service/main_test.go
+++ b/apps/dns-service/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
+	t.Parallel()
+
+	got, err := normalizePreviewACMEChallengeCNAME(" _ACME-PREVIEW.Example.NET ")
+	if err != nil {
+		t.Fatalf("normalize challenge CNAME: %v", err)
+	}
+	if got != "_acme-preview.example.net." {
+		t.Fatalf("normalized CNAME = %q", got)
+	}
+
+	for _, value := range []string{
+		"_acme-challenge.my.obiente.cloud",
+		"nested.my.obiente.cloud",
+		"invalid name",
+	} {
+		_, err := normalizePreviewACMEChallengeCNAME(value)
+		if err == nil {
+			t.Errorf("invalid CNAME target %q was accepted", value)
+		}
+	}
+
+	if _, err := normalizePreviewACMEChallengeCNAME(""); err != nil {
+		t.Fatalf("empty optional CNAME: %v", err)
+	}
+}
+
+func TestHandlePreviewACMEChallengeReturnsCNAMEForTXTLookup(t *testing.T) {
+	t.Parallel()
+	server := &DNSServer{previewACMEChallengeCNAME: "_acme-preview.example.net."}
+	message := new(dns.Msg)
+	question := dns.Question{
+		Name:   previewACMEChallengeName,
+		Qtype:  dns.TypeTXT,
+		Qclass: dns.ClassINET,
+	}
+
+	if !server.handlePreviewACMEChallenge(message, question) {
+		t.Fatal("preview ACME challenge was not handled")
+	}
+	if len(message.Answer) != 1 {
+		t.Fatalf("answer count = %d, want 1", len(message.Answer))
+	}
+	cname, ok := message.Answer[0].(*dns.CNAME)
+	if !ok {
+		t.Fatalf("answer type = %T, want *dns.CNAME", message.Answer[0])
+	}
+	if cname.Hdr.Name != previewACMEChallengeName || cname.Target != server.previewACMEChallengeCNAME {
+		t.Fatalf("unexpected CNAME answer: %#v", cname)
+	}
+	if !strings.EqualFold(cname.Hdr.Name, question.Name) {
+		t.Fatalf("CNAME owner = %q, want %q", cname.Hdr.Name, question.Name)
+	}
+}
+
+func TestHandlePreviewACMEChallengeIgnoresOtherNamesAndMissingTarget(t *testing.T) {
+	t.Parallel()
+	message := new(dns.Msg)
+
+	server := &DNSServer{previewACMEChallengeCNAME: "_acme-preview.example.net."}
+	if server.handlePreviewACMEChallenge(message, dns.Question{Name: "app.my.obiente.cloud.", Qtype: dns.TypeTXT}) {
+		t.Fatal("non-challenge name was handled")
+	}
+
+	server.previewACMEChallengeCNAME = ""
+	if server.handlePreviewACMEChallenge(message, dns.Question{Name: previewACMEChallengeName, Qtype: dns.TypeTXT}) {
+		t.Fatal("challenge without a configured target was handled")
+	}
+}

--- a/apps/dns-service/main_test.go
+++ b/apps/dns-service/main_test.go
@@ -20,6 +20,7 @@ func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
 
 	for _, value := range []string{
 		"_acme-challenge.my.obiente.cloud",
+		"my.obiente.cloud",
 		"nested.my.obiente.cloud",
 		"invalid name",
 		"-invalid.example.net",

--- a/apps/shared/pkg/orchestrator/deployment_manager_config.go
+++ b/apps/shared/pkg/orchestrator/deployment_manager_config.go
@@ -676,6 +676,10 @@ func generateTraefikLabels(deploymentID string, serviceName string, routings []d
 			} else if routing.SSLCertResolver == "internal" {
 				// For internal SSL, don't set certresolver (let app handle it)
 				labels["traefik.http.routers."+routerName+".entrypoints"] = "web"
+			} else {
+				// TLS can use a certificate already present in Traefik's default
+				// store, such as the platform wildcard certificate for PR previews.
+				labels["traefik.http.routers."+routerName+".tls"] = "true"
 			}
 		} else {
 			// HTTP-only: explicitly set web entrypoint and ensure no TLS labels

--- a/apps/shared/pkg/orchestrator/deployment_manager_config_test.go
+++ b/apps/shared/pkg/orchestrator/deployment_manager_config_test.go
@@ -113,6 +113,20 @@ func TestGenerateTraefikLabelsAddsPreviewFallback(t *testing.T) {
 	}
 }
 
+func TestGenerateTraefikLabelsEnablesTLSWithoutPerRouteResolver(t *testing.T) {
+	t.Parallel()
+	labels := generateTraefikLabels("deployment-123", "default", []database.DeploymentRouting{{
+		ServiceName: "default", Domain: "pr-31-deployment-123.my.obiente.cloud", TargetPort: 3000,
+		Protocol: "https", SSLEnabled: true,
+	}}, nil, "deployment-preview-123")
+	if got := labels["traefik.http.routers.deployment-123.tls"]; got != "true" {
+		t.Fatalf("router TLS = %q, want true", got)
+	}
+	if _, exists := labels["traefik.http.routers.deployment-123.tls.certresolver"]; exists {
+		t.Fatal("wildcard-covered preview router requested a per-route certificate")
+	}
+}
+
 func TestGenerateTraefikLabelsDoesNotAddPreviewFallbackToOrdinaryDomain(t *testing.T) {
 	t.Parallel()
 	labels := generateTraefikLabels("deployment-123", "default", []database.DeploymentRouting{{

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -5,6 +5,29 @@
 # This file is automatically included by all compose files using the 'include' feature
 # (Docker Compose v2.20+). This allows YAML anchors to work across files.
 
+# Load provider-specific DNS credentials from a provider-neutral Swarm secret.
+# The credential file contains NAME=value lines using the names expected by the
+# selected lego DNS provider. Values are exported without evaluating shell code.
+x-traefik-dns-entrypoint: &traefik-dns-entrypoint
+  - /bin/sh
+  - -ec
+  - |
+    credentials_file=/run/secrets/preview_dns_credentials
+    while IFS= read -r credential || [ -n "$$credential" ]; do
+      case "$$credential" in
+        ""|\#*) continue ;;
+        *=*) ;;
+        *) echo "Invalid preview DNS credential entry" >&2; exit 1 ;;
+      esac
+      credential_name=$${credential%%=*}
+      case "$$credential_name" in
+        ""|[0-9]*|*[!A-Za-z0-9_]*) echo "Invalid preview DNS credential name" >&2; exit 1 ;;
+      esac
+      export "$$credential"
+    done < "$$credentials_file"
+    exec /entrypoint.sh "$$@"
+  - traefik-dns-wrapper
+
 x-common-database: &common-database
   DB_HOST: ${DB_HOST:-postgres}
   DB_PORT: ${DB_PORT:-5432}

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -5,29 +5,6 @@
 # This file is automatically included by all compose files using the 'include' feature
 # (Docker Compose v2.20+). This allows YAML anchors to work across files.
 
-# Load provider-specific DNS credentials from a provider-neutral Swarm secret.
-# The credential file contains NAME=value lines using the names expected by the
-# selected lego DNS provider. Values are exported without evaluating shell code.
-x-traefik-dns-entrypoint: &traefik-dns-entrypoint
-  - /bin/sh
-  - -ec
-  - |
-    credentials_file=/run/secrets/preview_dns_credentials
-    while IFS= read -r credential || [ -n "$$credential" ]; do
-      case "$$credential" in
-        ""|\#*) continue ;;
-        *=*) ;;
-        *) echo "Invalid preview DNS credential entry" >&2; exit 1 ;;
-      esac
-      credential_name=$${credential%%=*}
-      case "$$credential_name" in
-        ""|[0-9]*|*[!A-Za-z0-9_]*) echo "Invalid preview DNS credential name" >&2; exit 1 ;;
-      esac
-      export "$$credential"
-    done < "$$credentials_file"
-    exec /entrypoint.sh "$$@"
-  - traefik-dns-wrapper
-
 x-common-database: &common-database
   DB_HOST: ${DB_HOST:-postgres}
   DB_PORT: ${DB_PORT:-5432}

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -142,6 +142,7 @@ x-common-dns: &common-dns
   ENABLE_DNS: ${ENABLE_DNS:-true}
   NODE_IPS: ${NODE_IPS:-127.0.0.1}
   GAMESERVER_DNS_STALE_GRACE: ${GAMESERVER_DNS_STALE_GRACE:-2m}
+  PREVIEW_ACME_CHALLENGE_CNAME: ${PREVIEW_ACME_CHALLENGE_CNAME:-}
 
 x-common-security: &common-security
   SECRET: ${SECRET:-}

--- a/docker-compose.swarm.dev.yml
+++ b/docker-compose.swarm.dev.yml
@@ -472,6 +472,9 @@ services:
         - "traefik.http.routers.preview-domain-fallback-secure.entrypoints=websecure"
         - "traefik.http.routers.preview-domain-fallback-secure.priority=1"
         - "traefik.http.routers.preview-domain-fallback-secure.tls=true"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.certresolver=previewdns"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].main=my.obiente.cloud"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].sans=*.my.obiente.cloud"
         - "traefik.http.routers.preview-domain-fallback-secure.service=deployments-service"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:3005/health || exit 1"]
@@ -999,6 +1002,11 @@ services:
 
   traefik:
     image: traefik:v3.6.1
+    environment:
+      PREVIEW_ACME_DNS_PROVIDER: ${PREVIEW_ACME_DNS_PROVIDER:-}
+    secrets:
+      - preview_dns_credentials
+    entrypoint: *traefik-dns-entrypoint
     command:
       - --api.dashboard=true
       - --api.insecure=true  # Enable API on port 8080 directly
@@ -1033,6 +1041,11 @@ services:
       # Set ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory to avoid rate limits during testing
       # Default: production (https://acme-v02.api.letsencrypt.org/directory)
       - --certificatesresolvers.letsencrypt.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
+      # Wildcard certificate shared by PR state pages and live preview routers.
+      - --certificatesresolvers.previewdns.acme.email=${ACME_EMAIL:-admin@example.com}
+      - --certificatesresolvers.previewdns.acme.storage=/letsencrypt/acme-preview.json
+      - --certificatesresolvers.previewdns.acme.dnschallenge.provider=${PREVIEW_ACME_DNS_PROVIDER:-}
+      - --certificatesresolvers.previewdns.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       # Metrics
       - --metrics.prometheus=true
       # Logging
@@ -1317,3 +1330,7 @@ configs:
   # Init script to copy pg_hba.conf to PGDATA
   postgres_hba_init:
     file: ./scripts/internal/init-pg-hba.sh
+
+secrets:
+  preview_dns_credentials:
+    external: true

--- a/docker-compose.swarm.dev.yml
+++ b/docker-compose.swarm.dev.yml
@@ -472,9 +472,6 @@ services:
         - "traefik.http.routers.preview-domain-fallback-secure.entrypoints=websecure"
         - "traefik.http.routers.preview-domain-fallback-secure.priority=1"
         - "traefik.http.routers.preview-domain-fallback-secure.tls=true"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.certresolver=previewdns"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].main=my.obiente.cloud"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].sans=*.my.obiente.cloud"
         - "traefik.http.routers.preview-domain-fallback-secure.service=deployments-service"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:3005/health || exit 1"]
@@ -1002,11 +999,13 @@ services:
 
   traefik:
     image: traefik:v3.6.1
-    environment:
-      PREVIEW_ACME_DNS_PROVIDER: ${PREVIEW_ACME_DNS_PROVIDER:-}
     secrets:
-      - preview_dns_credentials
-    entrypoint: *traefik-dns-entrypoint
+      - preview_tls_cert
+      - preview_tls_key
+    configs:
+      - source: preview_tls_config
+        target: /etc/traefik/dynamic/preview-tls.yml
+        mode: 0444
     command:
       - --api.dashboard=true
       - --api.insecure=true  # Enable API on port 8080 directly
@@ -1015,6 +1014,8 @@ services:
       - --providers.swarm.watch=true  # Watch for service changes
       - --providers.swarm.refreshSeconds=5  # Poll Docker Swarm every 5 seconds for faster service discovery
       - --providers.swarm.constraints=Label(`cloud.obiente.traefik`,`true`)  # Only discover services with this label
+      - --providers.file.filename=/etc/traefik/dynamic/preview-tls.yml
+      - --providers.file.watch=true
       # Timeout configuration to fail faster on unreachable backends
       # dialTimeout: time to establish connection (increased to 10s to handle network delays)
       - --serversTransport.forwardingTimeouts.dialTimeout=10s
@@ -1041,11 +1042,6 @@ services:
       # Set ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory to avoid rate limits during testing
       # Default: production (https://acme-v02.api.letsencrypt.org/directory)
       - --certificatesresolvers.letsencrypt.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
-      # Wildcard certificate shared by PR state pages and live preview routers.
-      - --certificatesresolvers.previewdns.acme.email=${ACME_EMAIL:-admin@example.com}
-      - --certificatesresolvers.previewdns.acme.storage=/letsencrypt/acme-preview.json
-      - --certificatesresolvers.previewdns.acme.dnschallenge.provider=${PREVIEW_ACME_DNS_PROVIDER:-}
-      - --certificatesresolvers.previewdns.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       # Metrics
       - --metrics.prometheus=true
       # Logging
@@ -1324,6 +1320,8 @@ networks:
     #   name: ${MAIN_DEPLOYMENT_NETWORK:-obiente_obiente-network}
 
 configs:
+  preview_tls_config:
+    file: ./scripts/internal/traefik-preview-tls.yml
   # Custom pg_hba.conf file
   postgres_hba_conf:
     file: ./scripts/internal/pg_hba.conf
@@ -1332,5 +1330,9 @@ configs:
     file: ./scripts/internal/init-pg-hba.sh
 
 secrets:
-  preview_dns_credentials:
+  preview_tls_cert:
+    name: ${PREVIEW_TLS_CERT_SECRET:-preview_tls_cert}
+    external: true
+  preview_tls_key:
+    name: ${PREVIEW_TLS_KEY_SECRET:-preview_tls_key}
     external: true

--- a/docker-compose.swarm.ha.yml
+++ b/docker-compose.swarm.ha.yml
@@ -418,6 +418,11 @@ services:
   # Traefik - Dynamic reverse proxy with service discovery
   traefik:
     image: traefik:v3.6.1
+    environment:
+      PREVIEW_ACME_DNS_PROVIDER: ${PREVIEW_ACME_DNS_PROVIDER:-}
+    secrets:
+      - preview_dns_credentials
+    entrypoint: *traefik-dns-entrypoint
     command:
       - --api.dashboard=true
       - --api.insecure=false  # Use secure API (HTTPS only)
@@ -456,6 +461,11 @@ services:
       # Set ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory to avoid rate limits during testing
       # Default: production (https://acme-v02.api.letsencrypt.org/directory)
       - --certificatesresolvers.letsencrypt.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
+      # Wildcard certificate shared by PR state pages and live preview routers.
+      - --certificatesresolvers.previewdns.acme.email=${ACME_EMAIL}
+      - --certificatesresolvers.previewdns.acme.storage=/letsencrypt/acme-preview.json
+      - --certificatesresolvers.previewdns.acme.dnschallenge.provider=${PREVIEW_ACME_DNS_PROVIDER:-}
+      - --certificatesresolvers.previewdns.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       - --metrics.prometheus=true
       - --accesslog=true
       - --log.level=INFO
@@ -967,6 +977,9 @@ services:
         - "traefik.http.routers.preview-domain-fallback-secure.entrypoints=websecure"
         - "traefik.http.routers.preview-domain-fallback-secure.priority=1"
         - "traefik.http.routers.preview-domain-fallback-secure.tls=true"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.certresolver=previewdns"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].main=my.obiente.cloud"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].sans=*.my.obiente.cloud"
         - "traefik.http.routers.preview-domain-fallback-secure.service=deployments-service"
     healthcheck:
       test: ["CMD-SHELL", "sh -c 'if command -v nc >/dev/null 2>&1; then nc -z localhost 3005 || exit 1; else (apk add --no-cache netcat-openbsd >/dev/null 2>&1 || apt-get update -qq && apt-get install -y -qq netcat-openbsd >/dev/null 2>&1 || yum install -y -q nc >/dev/null 2>&1) && nc -z localhost 3005 || exit 1; fi'"]
@@ -1563,6 +1576,8 @@ networks:
 # ============================================================================
 
 secrets:
+  preview_dns_credentials:
+    external: true
   ssh_proxy_host_key:
     external: true
     # This secret must be created before deploying the stack:

--- a/docker-compose.swarm.ha.yml
+++ b/docker-compose.swarm.ha.yml
@@ -418,11 +418,13 @@ services:
   # Traefik - Dynamic reverse proxy with service discovery
   traefik:
     image: traefik:v3.6.1
-    environment:
-      PREVIEW_ACME_DNS_PROVIDER: ${PREVIEW_ACME_DNS_PROVIDER:-}
     secrets:
-      - preview_dns_credentials
-    entrypoint: *traefik-dns-entrypoint
+      - preview_tls_cert
+      - preview_tls_key
+    configs:
+      - source: preview_tls_config
+        target: /etc/traefik/dynamic/preview-tls.yml
+        mode: 0444
     command:
       - --api.dashboard=true
       - --api.insecure=false  # Use secure API (HTTPS only)
@@ -432,6 +434,8 @@ services:
       - --providers.swarm.watch=true  # Watch for service changes
       - --providers.swarm.refreshSeconds=5  # Poll Docker Swarm every 5 seconds for faster service discovery
       - --providers.swarm.constraints=Label(`cloud.obiente.traefik`,`true`)  # Only discover services with this label
+      - --providers.file.filename=/etc/traefik/dynamic/preview-tls.yml
+      - --providers.file.watch=true
       # Timeout configuration to fail faster on unreachable backends
       # dialTimeout: time to establish connection (increased to 10s to handle network delays)
       - --serversTransport.forwardingTimeouts.dialTimeout=10s
@@ -461,11 +465,6 @@ services:
       # Set ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory to avoid rate limits during testing
       # Default: production (https://acme-v02.api.letsencrypt.org/directory)
       - --certificatesresolvers.letsencrypt.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
-      # Wildcard certificate shared by PR state pages and live preview routers.
-      - --certificatesresolvers.previewdns.acme.email=${ACME_EMAIL}
-      - --certificatesresolvers.previewdns.acme.storage=/letsencrypt/acme-preview.json
-      - --certificatesresolvers.previewdns.acme.dnschallenge.provider=${PREVIEW_ACME_DNS_PROVIDER:-}
-      - --certificatesresolvers.previewdns.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       - --metrics.prometheus=true
       - --accesslog=true
       - --log.level=INFO
@@ -977,9 +976,6 @@ services:
         - "traefik.http.routers.preview-domain-fallback-secure.entrypoints=websecure"
         - "traefik.http.routers.preview-domain-fallback-secure.priority=1"
         - "traefik.http.routers.preview-domain-fallback-secure.tls=true"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.certresolver=previewdns"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].main=my.obiente.cloud"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].sans=*.my.obiente.cloud"
         - "traefik.http.routers.preview-domain-fallback-secure.service=deployments-service"
     healthcheck:
       test: ["CMD-SHELL", "sh -c 'if command -v nc >/dev/null 2>&1; then nc -z localhost 3005 || exit 1; else (apk add --no-cache netcat-openbsd >/dev/null 2>&1 || apt-get update -qq && apt-get install -y -qq netcat-openbsd >/dev/null 2>&1 || yum install -y -q nc >/dev/null 2>&1) && nc -z localhost 3005 || exit 1; fi'"]
@@ -1572,11 +1568,23 @@ networks:
       encrypted: "true"
 
 # ============================================================================
+# CONFIGS
+# ============================================================================
+
+configs:
+  preview_tls_config:
+    file: ./scripts/internal/traefik-preview-tls.yml
+
+# ============================================================================
 # SECRETS
 # ============================================================================
 
 secrets:
-  preview_dns_credentials:
+  preview_tls_cert:
+    name: ${PREVIEW_TLS_CERT_SECRET:-preview_tls_cert}
+    external: true
+  preview_tls_key:
+    name: ${PREVIEW_TLS_KEY_SECRET:-preview_tls_key}
     external: true
   ssh_proxy_host_key:
     external: true

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -472,6 +472,9 @@ services:
         - "traefik.http.routers.preview-domain-fallback-secure.entrypoints=websecure"
         - "traefik.http.routers.preview-domain-fallback-secure.priority=1"
         - "traefik.http.routers.preview-domain-fallback-secure.tls=true"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.certresolver=previewdns"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].main=my.obiente.cloud"
+        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].sans=*.my.obiente.cloud"
         - "traefik.http.routers.preview-domain-fallback-secure.service=deployments-service"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:3005/health || exit 1"]
@@ -1007,6 +1010,11 @@ services:
 
   traefik:
     image: traefik:v3.6.1
+    environment:
+      PREVIEW_ACME_DNS_PROVIDER: ${PREVIEW_ACME_DNS_PROVIDER:-}
+    secrets:
+      - preview_dns_credentials
+    entrypoint: *traefik-dns-entrypoint
     command:
       - --api.dashboard=true
       - --api.insecure=true  # Enable API on port 8080 directly
@@ -1040,6 +1048,11 @@ services:
       # Set ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory to avoid rate limits during testing
       # Default: production (https://acme-v02.api.letsencrypt.org/directory)
       - --certificatesresolvers.letsencrypt.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
+      # Wildcard certificate shared by PR state pages and live preview routers.
+      - --certificatesresolvers.previewdns.acme.email=${ACME_EMAIL:-admin@example.com}
+      - --certificatesresolvers.previewdns.acme.storage=/letsencrypt/acme-preview.json
+      - --certificatesresolvers.previewdns.acme.dnschallenge.provider=${PREVIEW_ACME_DNS_PROVIDER:-}
+      - --certificatesresolvers.previewdns.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       # Metrics
       - --metrics.prometheus=true
       # Logging
@@ -1317,6 +1330,8 @@ configs:
     file: ./scripts/internal/init-pg-hba.sh
 
 secrets:
+  preview_dns_credentials:
+    external: true
   ssh_proxy_host_key:
     external: true
     # This secret must be created before deploying the stack:

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -472,9 +472,6 @@ services:
         - "traefik.http.routers.preview-domain-fallback-secure.entrypoints=websecure"
         - "traefik.http.routers.preview-domain-fallback-secure.priority=1"
         - "traefik.http.routers.preview-domain-fallback-secure.tls=true"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.certresolver=previewdns"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].main=my.obiente.cloud"
-        - "traefik.http.routers.preview-domain-fallback-secure.tls.domains[0].sans=*.my.obiente.cloud"
         - "traefik.http.routers.preview-domain-fallback-secure.service=deployments-service"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:3005/health || exit 1"]
@@ -1010,11 +1007,13 @@ services:
 
   traefik:
     image: traefik:v3.6.1
-    environment:
-      PREVIEW_ACME_DNS_PROVIDER: ${PREVIEW_ACME_DNS_PROVIDER:-}
     secrets:
-      - preview_dns_credentials
-    entrypoint: *traefik-dns-entrypoint
+      - preview_tls_cert
+      - preview_tls_key
+    configs:
+      - source: preview_tls_config
+        target: /etc/traefik/dynamic/preview-tls.yml
+        mode: 0444
     command:
       - --api.dashboard=true
       - --api.insecure=true  # Enable API on port 8080 directly
@@ -1022,6 +1021,8 @@ services:
       - --providers.swarm.exposedbydefault=false
       - --providers.swarm.watch=true  # Watch for service changes
       - --providers.swarm.constraints=Label(`cloud.obiente.traefik`,`true`)  # Only discover services with this label
+      - --providers.file.filename=/etc/traefik/dynamic/preview-tls.yml
+      - --providers.file.watch=true
       # Timeout configuration to fail faster on unreachable backends
       # dialTimeout: time to establish connection (increased to 10s to handle network delays)
       - --serversTransport.forwardingTimeouts.dialTimeout=10s
@@ -1048,11 +1049,6 @@ services:
       # Set ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory to avoid rate limits during testing
       # Default: production (https://acme-v02.api.letsencrypt.org/directory)
       - --certificatesresolvers.letsencrypt.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
-      # Wildcard certificate shared by PR state pages and live preview routers.
-      - --certificatesresolvers.previewdns.acme.email=${ACME_EMAIL:-admin@example.com}
-      - --certificatesresolvers.previewdns.acme.storage=/letsencrypt/acme-preview.json
-      - --certificatesresolvers.previewdns.acme.dnschallenge.provider=${PREVIEW_ACME_DNS_PROVIDER:-}
-      - --certificatesresolvers.previewdns.acme.caserver=${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       # Metrics
       - --metrics.prometheus=true
       # Logging
@@ -1322,6 +1318,8 @@ networks:
       encrypted: "true"
 
 configs:
+  preview_tls_config:
+    file: ./scripts/internal/traefik-preview-tls.yml
   # Custom pg_hba.conf file
   postgres_hba_conf:
     file: ./scripts/internal/pg_hba.conf
@@ -1330,7 +1328,11 @@ configs:
     file: ./scripts/internal/init-pg-hba.sh
 
 secrets:
-  preview_dns_credentials:
+  preview_tls_cert:
+    name: ${PREVIEW_TLS_CERT_SECRET:-preview_tls_cert}
+    external: true
+  preview_tls_key:
+    name: ${PREVIEW_TLS_KEY_SECRET:-preview_tls_key}
     external: true
   ssh_proxy_host_key:
     external: true

--- a/docs/deployment/dns.md
+++ b/docs/deployment/dns.md
@@ -109,6 +109,15 @@ ns2.my.obiente.cloud.    IN    A    <NODE_2_IP>
 ns3.my.obiente.cloud.    IN    A    <NODE_3_IP>
 ```
 
+Wildcard preview certificates use a CNAME to place their DNS-01 TXT challenge
+outside this delegated zone. Set `PREVIEW_ACME_CHALLENGE_CNAME` to a name in a
+zone controlled by the selected ACME DNS provider. The bundled DNS service
+then answers the following alias automatically:
+
+```text
+_acme-challenge.my.obiente.cloud. IN CNAME <configured-challenge-name>.
+```
+
 **Best Practice**: Configure at least 2-3 nameservers, but you can configure one per node for maximum redundancy.
 
 ### Step 3: Verify DNS Resolution

--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -71,7 +71,9 @@ Edit `.env` with your configuration:
 - Set your domain name
 - Generate secrets for JWT and sessions
 
-### 4. Configure Preview TLS DNS Credentials
+### 4. Configure Preview TLS
+
+#### Standard Swarm Stack
 
 Traefik uses DNS-01 to obtain one wildcard certificate for `my.obiente.cloud`
 and `*.my.obiente.cloud`. This certificate covers both live pull request
@@ -84,6 +86,19 @@ Choose any DNS provider supported by
 ```bash
 PREVIEW_ACME_DNS_PROVIDER=<lego-provider-code>
 ```
+
+When the bundled DNS service is authoritative for `my.obiente.cloud`, delegate
+the ACME challenge to a name outside that zone which the selected provider can
+update. For example, an operator controlling `example.net` could use:
+
+```bash
+PREVIEW_ACME_CHALLENGE_CNAME=_acme-challenge-preview.example.net
+```
+
+The DNS service answers `_acme-challenge.my.obiente.cloud` with this CNAME.
+The ACME client follows it and publishes the TXT value through the selected
+provider. If `ENABLE_DNS=false` and the selected provider is directly
+authoritative for the preview zone, this CNAME is not required.
 
 Create a protected file containing the environment variables required by that
 provider, one `NAME=value` entry per line. Use the variable names from the
@@ -104,6 +119,30 @@ The Traefik wrapper validates credential names and exports them without
 printing their values. Do not place provider credentials in `.env` or commit
 them to the repository. The deployment script stops before changing the stack
 if the provider or secret is missing.
+
+#### HA Swarm Stack
+
+The HA stack does not run ACME independently in every Traefik replica. Issue
+the `my.obiente.cloud` and `*.my.obiente.cloud` certificate once using any ACME
+client or certificate service, then distribute the full chain and private key
+through versioned Docker Swarm secrets:
+
+```bash
+docker secret create preview_tls_cert_20260803 /secure/path/fullchain.pem
+docker secret create preview_tls_key_20260803 /secure/path/privkey.pem
+```
+
+Select those versions in `.env`:
+
+```bash
+PREVIEW_TLS_CERT_SECRET=preview_tls_cert_20260803
+PREVIEW_TLS_KEY_SECRET=preview_tls_key_20260803
+```
+
+Every Traefik replica receives the same certificate through Swarm and loads it
+from the file provider. To renew it, create new versioned secrets, update the
+two names, and deploy the stack. Remove old secrets only after no service
+references them.
 
 ### 5. Prepare All Nodes (Required)
 

--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -73,22 +73,13 @@ Edit `.env` with your configuration:
 
 ### 4. Configure Preview TLS
 
-#### Standard Swarm Stack
-
-Traefik uses DNS-01 to obtain one wildcard certificate for `my.obiente.cloud`
-and `*.my.obiente.cloud`. This certificate covers both live pull request
-previews and the preview status page shown while a preview is not running.
-
-Choose any DNS provider supported by
-[lego](https://go-acme.github.io/lego/dns/), then set its provider code in
-`.env`:
-
-```bash
-PREVIEW_ACME_DNS_PROVIDER=<lego-provider-code>
-```
+Issue one certificate that covers `my.obiente.cloud` and
+`*.my.obiente.cloud` using any ACME client, DNS provider, or certificate
+service. This certificate covers both live pull request previews and the
+preview status page shown while a preview is not running.
 
 When the bundled DNS service is authoritative for `my.obiente.cloud`, delegate
-the ACME challenge to a name outside that zone which the selected provider can
+DNS-01 validation to a name outside that zone which the certificate issuer can
 update. For example, an operator controlling `example.net` could use:
 
 ```bash
@@ -96,36 +87,13 @@ PREVIEW_ACME_CHALLENGE_CNAME=_acme-challenge-preview.example.net
 ```
 
 The DNS service answers `_acme-challenge.my.obiente.cloud` with this CNAME.
-The ACME client follows it and publishes the TXT value through the selected
-provider. If `ENABLE_DNS=false` and the selected provider is directly
-authoritative for the preview zone, this CNAME is not required.
+The ACME client follows it and publishes the TXT value through its configured
+provider. If `ENABLE_DNS=false` and that provider is directly authoritative for
+the preview zone, this CNAME is not required. The target must be outside the
+entire `my.obiente.cloud` zone, including its apex.
 
-Create a protected file containing the environment variables required by that
-provider, one `NAME=value` entry per line. Use the variable names from the
-provider's lego documentation. Blank lines and lines beginning with `#` are
-allowed. Create one provider-neutral external Docker secret from that file:
-
-```bash
-docker secret create preview_dns_credentials /secure/path/preview-dns-credentials
-```
-
-Verify that the secret exists:
-
-```bash
-docker secret inspect preview_dns_credentials >/dev/null
-```
-
-The Traefik wrapper validates credential names and exports them without
-printing their values. Do not place provider credentials in `.env` or commit
-them to the repository. The deployment script stops before changing the stack
-if the provider or secret is missing.
-
-#### HA Swarm Stack
-
-The HA stack does not run ACME independently in every Traefik replica. Issue
-the `my.obiente.cloud` and `*.my.obiente.cloud` certificate once using any ACME
-client or certificate service, then distribute the full chain and private key
-through versioned Docker Swarm secrets:
+Distribute the issued full chain and private key through versioned Docker
+Swarm secrets:
 
 ```bash
 docker secret create preview_tls_cert_20260803 /secure/path/fullchain.pem
@@ -139,10 +107,13 @@ PREVIEW_TLS_CERT_SECRET=preview_tls_cert_20260803
 PREVIEW_TLS_KEY_SECRET=preview_tls_key_20260803
 ```
 
-Every Traefik replica receives the same certificate through Swarm and loads it
-from the file provider. To renew it, create new versioned secrets, update the
-two names, and deploy the stack. Remove old secrets only after no service
-references them.
+Every Traefik replica in the standard, development, and HA stacks receives the
+same certificate through Swarm and loads it from the file provider. This avoids
+independent ACME orders and renewal races on multi-manager clusters. To renew
+the certificate, create new versioned secrets, update the two names, and deploy
+the stack. Remove old secrets only after no service references them. The
+deployment scripts stop before changing the stack when either selected secret
+is missing.
 
 ### 5. Prepare All Nodes (Required)
 

--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -71,7 +71,41 @@ Edit `.env` with your configuration:
 - Set your domain name
 - Generate secrets for JWT and sessions
 
-### 4. Prepare All Nodes (Required)
+### 4. Configure Preview TLS DNS Credentials
+
+Traefik uses DNS-01 to obtain one wildcard certificate for `my.obiente.cloud`
+and `*.my.obiente.cloud`. This certificate covers both live pull request
+previews and the preview status page shown while a preview is not running.
+
+Choose any DNS provider supported by
+[lego](https://go-acme.github.io/lego/dns/), then set its provider code in
+`.env`:
+
+```bash
+PREVIEW_ACME_DNS_PROVIDER=<lego-provider-code>
+```
+
+Create a protected file containing the environment variables required by that
+provider, one `NAME=value` entry per line. Use the variable names from the
+provider's lego documentation. Blank lines and lines beginning with `#` are
+allowed. Create one provider-neutral external Docker secret from that file:
+
+```bash
+docker secret create preview_dns_credentials /secure/path/preview-dns-credentials
+```
+
+Verify that the secret exists:
+
+```bash
+docker secret inspect preview_dns_credentials >/dev/null
+```
+
+The Traefik wrapper validates credential names and exports them without
+printing their values. Do not place provider credentials in `.env` or commit
+them to the repository. The deployment script stops before changing the stack
+if the provider or secret is missing.
+
+### 5. Prepare All Nodes (Required)
 
 The API service runs on **ALL nodes** (mode: global). You **must** create required directories on each node before deploying:
 
@@ -105,7 +139,7 @@ for node in manager-1 worker-1 worker-2; do
 done
 ```
 
-### 4.5. Configure Node Labels (Required for Non-HA)
+### 6. Configure Node Labels (Required for Non-HA)
 
 For non-HA deployments, you must label nodes to specify where database services should run. This gives you control over which nodes host PostgreSQL, TimescaleDB, and Redis.
 
@@ -146,7 +180,7 @@ docker node inspect <node-name-or-id> --pretty
 
 **Note:** You can use the same node for all database services, or distribute them across different nodes. The labels allow you to control placement precisely.
 
-### 5. Deploy the Stack
+### 7. Deploy the Stack
 
 Deploy to the Swarm cluster:
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -851,29 +851,25 @@ METRICS_RETRY_MAX_QUEUE_SIZE=50000
 | -------------------------------- | ------ | --------------------- | ----------------------------------------- |
 | `DOMAIN`                         | string | `obiente.example.com` | ❌                                        |
 | `ACME_EMAIL`                     | string | -                     | ❌ (for Let's Encrypt)                    |
-| `PREVIEW_ACME_DNS_PROVIDER`      | string | -                     | ✅ (standard PR preview TLS)              |
-| `PREVIEW_ACME_CHALLENGE_CNAME`   | string | -                     | ✅ when the bundled DNS service is active |
-| `PREVIEW_TLS_CERT_SECRET`        | string | `preview_tls_cert`    | ❌ (HA certificate rotation)              |
-| `PREVIEW_TLS_KEY_SECRET`         | string | `preview_tls_key`     | ❌ (HA certificate rotation)              |
+| `PREVIEW_ACME_CHALLENGE_CNAME`   | string | -                     | ❌ (external DNS-01 delegation)            |
+| `PREVIEW_TLS_CERT_SECRET`        | string | `preview_tls_cert`    | ❌ (certificate rotation)                  |
+| `PREVIEW_TLS_KEY_SECRET`         | string | `preview_tls_key`     | ❌ (certificate rotation)                  |
 
 **Example:**
 
 ```bash
 DOMAIN=obiente.cloud
 ACME_EMAIL=admin@obiente.cloud
-PREVIEW_ACME_DNS_PROVIDER=<lego-provider-code>
 PREVIEW_ACME_CHALLENGE_CNAME=_acme-challenge-preview.example.net
 PREVIEW_TLS_CERT_SECRET=preview_tls_cert_20260803
 PREVIEW_TLS_KEY_SECRET=preview_tls_key_20260803
 ```
 
-`PREVIEW_ACME_DNS_PROVIDER` accepts any DNS provider code supported by lego.
-Provider-specific credentials belong in the `preview_dns_credentials` Docker
-secret, not in `.env`. When Obiente's DNS service is authoritative,
-`PREVIEW_ACME_CHALLENGE_CNAME` must point to a name outside
-`my.obiente.cloud` that the selected provider can update. HA deployments use
-the two versioned certificate secret names instead of issuing certificates in
-each Traefik replica.
+When Obiente's DNS service is authoritative, an external ACME client can use
+`PREVIEW_ACME_CHALLENGE_CNAME` to delegate DNS-01 validation to a name outside
+`my.obiente.cloud` that its selected provider can update. Every Swarm stack
+loads the resulting certificate from the two versioned certificate secrets so
+multiple Traefik replicas never issue or renew the same wildcard independently.
 
 ### DNS Configuration
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -847,11 +847,14 @@ METRICS_RETRY_MAX_QUEUE_SIZE=50000
 
 ### Domain & SSL
 
-| Variable                    | Type   | Default               | Required                        |
-| --------------------------- | ------ | --------------------- | ------------------------------- |
-| `DOMAIN`                    | string | `obiente.example.com` | ❌                              |
-| `ACME_EMAIL`                | string | -                     | ❌ (for Let's Encrypt)          |
-| `PREVIEW_ACME_DNS_PROVIDER` | string | -                     | ✅ (for pull request previews)  |
+| Variable                         | Type   | Default               | Required                                  |
+| -------------------------------- | ------ | --------------------- | ----------------------------------------- |
+| `DOMAIN`                         | string | `obiente.example.com` | ❌                                        |
+| `ACME_EMAIL`                     | string | -                     | ❌ (for Let's Encrypt)                    |
+| `PREVIEW_ACME_DNS_PROVIDER`      | string | -                     | ✅ (standard PR preview TLS)              |
+| `PREVIEW_ACME_CHALLENGE_CNAME`   | string | -                     | ✅ when the bundled DNS service is active |
+| `PREVIEW_TLS_CERT_SECRET`        | string | `preview_tls_cert`    | ❌ (HA certificate rotation)              |
+| `PREVIEW_TLS_KEY_SECRET`         | string | `preview_tls_key`     | ❌ (HA certificate rotation)              |
 
 **Example:**
 
@@ -859,11 +862,18 @@ METRICS_RETRY_MAX_QUEUE_SIZE=50000
 DOMAIN=obiente.cloud
 ACME_EMAIL=admin@obiente.cloud
 PREVIEW_ACME_DNS_PROVIDER=<lego-provider-code>
+PREVIEW_ACME_CHALLENGE_CNAME=_acme-challenge-preview.example.net
+PREVIEW_TLS_CERT_SECRET=preview_tls_cert_20260803
+PREVIEW_TLS_KEY_SECRET=preview_tls_key_20260803
 ```
 
 `PREVIEW_ACME_DNS_PROVIDER` accepts any DNS provider code supported by lego.
 Provider-specific credentials belong in the `preview_dns_credentials` Docker
-secret, not in `.env`.
+secret, not in `.env`. When Obiente's DNS service is authoritative,
+`PREVIEW_ACME_CHALLENGE_CNAME` must point to a name outside
+`my.obiente.cloud` that the selected provider can update. HA deployments use
+the two versioned certificate secret names instead of issuing certificates in
+each Traefik replica.
 
 ### DNS Configuration
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -847,17 +847,23 @@ METRICS_RETRY_MAX_QUEUE_SIZE=50000
 
 ### Domain & SSL
 
-| Variable     | Type   | Default               | Required               |
-| ------------ | ------ | --------------------- | ---------------------- |
-| `DOMAIN`     | string | `obiente.example.com` | ❌                     |
-| `ACME_EMAIL` | string | -                     | ❌ (for Let's Encrypt) |
+| Variable                    | Type   | Default               | Required                        |
+| --------------------------- | ------ | --------------------- | ------------------------------- |
+| `DOMAIN`                    | string | `obiente.example.com` | ❌                              |
+| `ACME_EMAIL`                | string | -                     | ❌ (for Let's Encrypt)          |
+| `PREVIEW_ACME_DNS_PROVIDER` | string | -                     | ✅ (for pull request previews)  |
 
 **Example:**
 
 ```bash
 DOMAIN=obiente.cloud
 ACME_EMAIL=admin@obiente.cloud
+PREVIEW_ACME_DNS_PROVIDER=<lego-provider-code>
 ```
+
+`PREVIEW_ACME_DNS_PROVIDER` accepts any DNS provider code supported by lego.
+Provider-specific credentials belong in the `preview_dns_credentials` Docker
+secret, not in `.env`.
 
 ### DNS Configuration
 

--- a/scripts/deploy-swarm-dev.sh
+++ b/scripts/deploy-swarm-dev.sh
@@ -193,6 +193,11 @@ sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$
 # Bind mounts with relative paths must exist on every node, so we convert them to absolute paths
 sed -i "s|\\./monitoring/|${REPO_ROOT}/monitoring/|g" "$MERGED_COMPOSE"
 
+# DNS credentials are required before Traefik can obtain the wildcard
+# certificate used by PR preview domains and their always-on status pages.
+require_environment_variables PREVIEW_ACME_DNS_PROVIDER
+require_swarm_secrets preview_dns_credentials
+
 # Verify config files exist before deploying
 echo "🔍 Verifying Docker config files exist..."
 CONFIG_FILES=(

--- a/scripts/deploy-swarm-dev.sh
+++ b/scripts/deploy-swarm-dev.sh
@@ -193,10 +193,9 @@ sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$
 # Bind mounts with relative paths must exist on every node, so we convert them to absolute paths
 sed -i "s|\\./monitoring/|${REPO_ROOT}/monitoring/|g" "$MERGED_COMPOSE"
 
-# DNS credentials are required before Traefik can obtain the wildcard
-# certificate used by PR preview domains and their always-on status pages.
-require_environment_variables PREVIEW_ACME_DNS_PROVIDER
-require_swarm_secrets preview_dns_credentials
+# Standard stacks issue the wildcard through DNS-01. HA stacks consume a
+# wildcard certificate distributed through Swarm secrets.
+require_preview_tls_configuration "$COMPOSE_FILE"
 
 # Verify config files exist before deploying
 echo "🔍 Verifying Docker config files exist..."
@@ -204,6 +203,9 @@ CONFIG_FILES=(
   "${REPO_ROOT}/scripts/internal/pg_hba.conf"
   "${REPO_ROOT}/scripts/internal/init-pg-hba.sh"
 )
+if grep -q "preview_tls_config:" "$COMPOSE_FILE"; then
+  CONFIG_FILES+=("${REPO_ROOT}/scripts/internal/traefik-preview-tls.yml")
+fi
 MISSING_CONFIGS=()
 for config_file in "${CONFIG_FILES[@]}"; do
   if [ ! -f "$config_file" ]; then

--- a/scripts/deploy-swarm-dev.sh
+++ b/scripts/deploy-swarm-dev.sh
@@ -193,8 +193,8 @@ sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$
 # Bind mounts with relative paths must exist on every node, so we convert them to absolute paths
 sed -i "s|\\./monitoring/|${REPO_ROOT}/monitoring/|g" "$MERGED_COMPOSE"
 
-# Standard stacks issue the wildcard through DNS-01. HA stacks consume a
-# wildcard certificate distributed through Swarm secrets.
+# Every Traefik replica consumes the same wildcard certificate through Swarm
+# secrets, avoiding duplicate ACME orders in multi-manager stacks.
 require_preview_tls_configuration "$COMPOSE_FILE"
 
 # Verify config files exist before deploying

--- a/scripts/deploy-swarm.sh
+++ b/scripts/deploy-swarm.sh
@@ -252,8 +252,8 @@ sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$
 # Bind mounts with relative paths must exist on every node, so we convert them to absolute paths
 sed -i "s|\\./monitoring/|${REPO_ROOT}/monitoring/|g" "$MERGED_COMPOSE"
 
-# Standard stacks issue the wildcard through DNS-01. HA stacks consume a
-# wildcard certificate distributed through Swarm secrets.
+# Every Traefik replica consumes the same wildcard certificate through Swarm
+# secrets, avoiding duplicate ACME orders in multi-manager stacks.
 require_preview_tls_configuration "$COMPOSE_FILE"
 
 # Verify config files exist before deploying

--- a/scripts/deploy-swarm.sh
+++ b/scripts/deploy-swarm.sh
@@ -252,10 +252,9 @@ sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$
 # Bind mounts with relative paths must exist on every node, so we convert them to absolute paths
 sed -i "s|\\./monitoring/|${REPO_ROOT}/monitoring/|g" "$MERGED_COMPOSE"
 
-# DNS credentials are required before Traefik can obtain the wildcard
-# certificate used by PR preview domains and their always-on status pages.
-require_environment_variables PREVIEW_ACME_DNS_PROVIDER
-require_swarm_secrets preview_dns_credentials
+# Standard stacks issue the wildcard through DNS-01. HA stacks consume a
+# wildcard certificate distributed through Swarm secrets.
+require_preview_tls_configuration "$COMPOSE_FILE"
 
 # Verify config files exist before deploying
 echo "🔍 Verifying Docker config files exist..."
@@ -263,6 +262,9 @@ CONFIG_FILES=(
   "${REPO_ROOT}/scripts/internal/pg_hba.conf"
   "${REPO_ROOT}/scripts/internal/init-pg-hba.sh"
 )
+if grep -q "preview_tls_config:" "$COMPOSE_FILE"; then
+  CONFIG_FILES+=("${REPO_ROOT}/scripts/internal/traefik-preview-tls.yml")
+fi
 MISSING_CONFIGS=()
 for config_file in "${CONFIG_FILES[@]}"; do
   if [ ! -f "$config_file" ]; then

--- a/scripts/deploy-swarm.sh
+++ b/scripts/deploy-swarm.sh
@@ -252,6 +252,11 @@ sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$
 # Bind mounts with relative paths must exist on every node, so we convert them to absolute paths
 sed -i "s|\\./monitoring/|${REPO_ROOT}/monitoring/|g" "$MERGED_COMPOSE"
 
+# DNS credentials are required before Traefik can obtain the wildcard
+# certificate used by PR preview domains and their always-on status pages.
+require_environment_variables PREVIEW_ACME_DNS_PROVIDER
+require_swarm_secrets preview_dns_credentials
+
 # Verify config files exist before deploying
 echo "🔍 Verifying Docker config files exist..."
 CONFIG_FILES=(

--- a/scripts/force-deploy.sh
+++ b/scripts/force-deploy.sh
@@ -79,6 +79,9 @@ sed -i "s/__STACK_NAME__/${STACK_NAME}/g" "$MERGED_COMPOSE"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$MERGED_COMPOSE"
 
+require_environment_variables PREVIEW_ACME_DNS_PROVIDER
+require_swarm_secrets preview_dns_credentials
+
 docker stack deploy --resolve-image always -c "$MERGED_COMPOSE" "$STACK_NAME"
 rm -f "$MERGED_COMPOSE"
 echo -e "${GREEN}✅ Main stack redeployed!${NC}"

--- a/scripts/force-deploy.sh
+++ b/scripts/force-deploy.sh
@@ -79,8 +79,7 @@ sed -i "s/__STACK_NAME__/${STACK_NAME}/g" "$MERGED_COMPOSE"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 sed -i "s|file: \\./scripts/internal/|file: ${REPO_ROOT}/scripts/internal/|g" "$MERGED_COMPOSE"
 
-require_environment_variables PREVIEW_ACME_DNS_PROVIDER
-require_swarm_secrets preview_dns_credentials
+require_preview_tls_configuration "$COMPOSE_FILE"
 
 docker stack deploy --resolve-image always -c "$MERGED_COMPOSE" "$STACK_NAME"
 rm -f "$MERGED_COMPOSE"

--- a/scripts/internal/traefik-preview-tls.yml
+++ b/scripts/internal/traefik-preview-tls.yml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: /run/secrets/preview_tls_cert
+      keyFile: /run/secrets/preview_tls_key

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -54,6 +54,55 @@ load_env_file() {
   done < "$env_file"
 }
 
+require_swarm_secrets() {
+  local secret_name=""
+  local -a missing_secrets=()
+
+  for secret_name in "$@"; do
+    if ! docker secret inspect "$secret_name" >/dev/null 2>&1; then
+      missing_secrets+=("$secret_name")
+    fi
+  done
+
+  if [ ${#missing_secrets[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  echo "❌ Error: Required Docker Swarm secrets are missing:"
+  for secret_name in "${missing_secrets[@]}"; do
+    echo "   - $secret_name"
+  done
+  echo ""
+  echo "Create each secret from a protected file before deploying:"
+  for secret_name in "${missing_secrets[@]}"; do
+    echo "   docker secret create $secret_name /secure/path/$secret_name"
+  done
+  echo ""
+  echo "Do not store these credentials in .env or commit them to the repository."
+  return 1
+}
+
+require_environment_variables() {
+  local variable_name=""
+  local -a missing_variables=()
+
+  for variable_name in "$@"; do
+    if [ -z "${!variable_name:-}" ]; then
+      missing_variables+=("$variable_name")
+    fi
+  done
+
+  if [ ${#missing_variables[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  echo "❌ Error: Required environment variables are missing:"
+  for variable_name in "${missing_variables[@]}"; do
+    echo "   - $variable_name"
+  done
+  return 1
+}
+
 PARALLEL_PULL_FAILURES=()
 
 wait_for_pull_slot() {

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -103,6 +103,29 @@ require_environment_variables() {
   return 1
 }
 
+require_preview_tls_configuration() {
+  local compose_file="$1"
+
+  if grep -Eq '^[[:space:]]+- preview_dns_credentials[[:space:]]*$' "$compose_file"; then
+    require_environment_variables PREVIEW_ACME_DNS_PROVIDER || return 1
+    require_swarm_secrets preview_dns_credentials || return 1
+
+    case "${ENABLE_DNS:-true}" in
+      false|0)
+        ;;
+      *)
+        require_environment_variables PREVIEW_ACME_CHALLENGE_CNAME || return 1
+        ;;
+    esac
+  fi
+
+  if grep -Eq '^[[:space:]]+- preview_tls_cert[[:space:]]*$' "$compose_file"; then
+    require_swarm_secrets \
+      "${PREVIEW_TLS_CERT_SECRET:-preview_tls_cert}" \
+      "${PREVIEW_TLS_KEY_SECRET:-preview_tls_key}" || return 1
+  fi
+}
+
 PARALLEL_PULL_FAILURES=()
 
 wait_for_pull_slot() {

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -82,42 +82,8 @@ require_swarm_secrets() {
   return 1
 }
 
-require_environment_variables() {
-  local variable_name=""
-  local -a missing_variables=()
-
-  for variable_name in "$@"; do
-    if [ -z "${!variable_name:-}" ]; then
-      missing_variables+=("$variable_name")
-    fi
-  done
-
-  if [ ${#missing_variables[@]} -eq 0 ]; then
-    return 0
-  fi
-
-  echo "❌ Error: Required environment variables are missing:"
-  for variable_name in "${missing_variables[@]}"; do
-    echo "   - $variable_name"
-  done
-  return 1
-}
-
 require_preview_tls_configuration() {
   local compose_file="$1"
-
-  if grep -Eq '^[[:space:]]+- preview_dns_credentials[[:space:]]*$' "$compose_file"; then
-    require_environment_variables PREVIEW_ACME_DNS_PROVIDER || return 1
-    require_swarm_secrets preview_dns_credentials || return 1
-
-    case "${ENABLE_DNS:-true}" in
-      false|0)
-        ;;
-      *)
-        require_environment_variables PREVIEW_ACME_CHALLENGE_CNAME || return 1
-        ;;
-    esac
-  fi
 
   if grep -Eq '^[[:space:]]+- preview_tls_cert[[:space:]]*$' "$compose_file"; then
     require_swarm_secrets \


### PR DESCRIPTION
## Summary

- load one wildcard certificate for `my.obiente.cloud` and `*.my.obiente.cloud` into every Traefik replica through versioned Swarm secrets
- let running preview routers and the permanent fallback router use that shared certificate
- support provider-neutral DNS-01 delegation through the bundled authoritative DNS service
- reject challenge aliases anywhere inside the delegated preview zone
- migrate existing preview routes to the shared-certificate configuration
- stop deployment before changing the stack when either selected certificate secret is missing
- document issuance, secret rotation, and self-hosted DNS delegation

## Root cause

The HTTPS fallback router enabled TLS without owning a matching certificate, so Traefik served its generated default certificate whenever the preview backend was absent. Running preview routes also requested individual certificates, which did not cover the fallback state and scaled ACME orders with the number of pull requests.

Issuing the shared wildcard independently from every globally deployed Traefik replica would introduce DNS challenge races and CA rate-limit pressure. The standard, development, and HA Swarm stacks now load the same externally issued certificate instead.

## Validation

- `gofmt` applied to the changed Go files
- all standard, development, and HA Swarm configurations pass `docker compose config --quiet` after base-file merging
- deployment shell files pass `bash -n`
- versioned certificate-secret preflight checked across all three Swarm variants
- `git diff --check` passes
- build and Go test validation delegated to GitHub Actions
