### PR TITLE
fix(deployments): roll out exact preview revisions

### DIFF
--- a/apps/deployments-service/internal/service/image_cleanup.go
+++ b/apps/deployments-service/internal/service/image_cleanup.go
@@ -99,6 +99,17 @@ func cleanupCallerOwnsLiveImage(callerImage string, liveImage *string) bool {
 	return liveImage != nil && strings.TrimSpace(callerImage) != "" && strings.TrimSpace(callerImage) == strings.TrimSpace(*liveImage)
 }
 
+func currentDeploymentImage(ctx context.Context, deploymentID string) (*string, error) {
+	var deployment database.Deployment
+	if err := database.DB.WithContext(ctx).
+		Select("image").
+		Where("id = ? AND deleted_at IS NULL", deploymentID).
+		First(&deployment).Error; err != nil {
+		return nil, err
+	}
+	return deployment.Image, nil
+}
+
 func revisionImageAliases(deploymentID, branch, commitSHA, registryURL string) []string {
 	commitSHA = strings.TrimSpace(commitSHA)
 	if !isGitHubCommitSHA(commitSHA) {
@@ -181,19 +192,16 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 	// Read through the database instead of the deployment repository cache. A
 	// cleanup can be delayed while newer revisions finish, and only the actual
 	// live image may determine which preceding revision is rollback-safe.
-	var deployment database.Deployment
-	if err := database.DB.WithContext(ctx).
-		Select("image", "branch").
-		Where("id = ? AND deleted_at IS NULL", deploymentID).
-		First(&deployment).Error; err != nil {
+	liveImage, err := currentDeploymentImage(ctx, deploymentID)
+	if err != nil {
 		logger.Warn("[ImageCleanup] Failed to read live image for deployment %s: %v", deploymentID, err)
 		return
 	}
-	if !cleanupCallerOwnsLiveImage(callerImage, deployment.Image) {
+	if !cleanupCallerOwnsLiveImage(callerImage, liveImage) {
 		logger.Info("[ImageCleanup] Skipping stale cleanup for deployment %s because a newer image is live", deploymentID)
 		return
 	}
-	currentImage := strings.TrimSpace(*deployment.Image)
+	currentImage := strings.TrimSpace(*liveImage)
 
 	builds, _, err := s.buildHistoryRepo.ListBuilds(ctx, deploymentID, organizationID, 0, 0)
 	if err != nil {
@@ -221,6 +229,15 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 	protectRegistryImageDigests(ctx, client, registryURL, kept, protectedDigests, unsafeRepositories)
 
 	for _, image := range obsolete {
+		liveImage, err = currentDeploymentImage(ctx, deploymentID)
+		if err != nil {
+			logger.Warn("[ImageCleanup] Stopping cleanup for deployment %s because its live image could not be refreshed: %v", deploymentID, err)
+			return
+		}
+		if !cleanupCallerOwnsLiveImage(callerImage, liveImage) {
+			logger.Info("[ImageCleanup] Stopping stale cleanup for deployment %s because a newer image became live", deploymentID)
+			return
+		}
 		activeImages, activeUnknown, err = s.currentRevisionImageReservations(ctx, deploymentID, organizationID, registryURL)
 		if err != nil || activeUnknown {
 			logger.Warn("[ImageCleanup] Stopping cleanup for deployment %s because active revision ownership changed: %v", deploymentID, err)

--- a/apps/deployments-service/internal/service/image_cleanup.go
+++ b/apps/deployments-service/internal/service/image_cleanup.go
@@ -14,32 +14,56 @@ import (
 	"github.com/obiente/cloud/apps/shared/pkg/database"
 	"github.com/obiente/cloud/apps/shared/pkg/logger"
 	"github.com/obiente/cloud/apps/shared/pkg/platform"
+
+	deploymentsv1 "github.com/obiente/cloud/apps/shared/proto/obiente/cloud/deployments/v1"
 )
 
 var revisionImageTagPattern = regexp.MustCompile(`-[a-fA-F0-9]{40}(?:[a-fA-F0-9]{24})?$`)
 
 const registryManifestAccept = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json"
 
-// retainedRevisionImages keeps the currently deployed image and one prior
-// successful image for rollback. Older build records remain available without
-// retaining every immutable image tag.
+// retainedRevisionImages keeps the currently deployed image, one prior image
+// that passed runtime verification, active build images, and stable mutable
+// tags. Older build records remain available without retaining every immutable
+// revision tag.
 func retainedRevisionImages(builds []*database.BuildHistory, currentImage string) (map[string]struct{}, []string) {
-	kept := make(map[string]struct{}, 2)
+	kept := make(map[string]struct{})
 	if currentImage = strings.TrimSpace(currentImage); currentImage != "" {
 		kept[currentImage] = struct{}{}
 	}
+	rollbackRetained := false
 	for _, build := range builds {
-		if build.Status != 3 || build.ImageName == nil {
+		if build.ImageName == nil {
 			continue
 		}
 		image := strings.TrimSpace(*build.ImageName)
 		if image == "" {
 			continue
 		}
-		kept[image] = struct{}{}
-		if len(kept) >= 2 {
-			break
+
+		// Mutable branch tags do not accumulate and may share a manifest with
+		// an immutable revision tag, so never delete their backing manifest.
+		if !isRevisionTaggedImage(image) {
+			kept[image] = struct{}{}
+			continue
 		}
+		// A preceding cleanup can overlap the next build after the lease is
+		// released. Protect any image already produced by that active build.
+		if build.Status == int32(deploymentsv1.BuildStatus_BUILD_PENDING) ||
+			build.Status == int32(deploymentsv1.BuildStatus_BUILD_BUILDING) {
+			kept[image] = struct{}{}
+			continue
+		}
+		// Runtime startup failures deliberately retain BUILD_SUCCESS with an
+		// error for build-history accuracy, but are not rollback candidates.
+		if build.Status != int32(deploymentsv1.BuildStatus_BUILD_SUCCESS) || build.Error != nil || rollbackRetained {
+			continue
+		}
+		if _, current := kept[image]; current {
+			continue
+		}
+		kept[image] = struct{}{}
+		rollbackRetained = true
 	}
 
 	obsoleteSet := make(map[string]struct{})

--- a/apps/deployments-service/internal/service/image_cleanup.go
+++ b/apps/deployments-service/internal/service/image_cleanup.go
@@ -2,6 +2,7 @@ package deployments
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/obiente/cloud/apps/shared/pkg/platform"
 
 	deploymentsv1 "github.com/obiente/cloud/apps/shared/proto/obiente/cloud/deployments/v1"
+	"gorm.io/gorm"
 )
 
 var revisionImageTagPattern = regexp.MustCompile(`-[a-fA-F0-9]{40}(?:[a-fA-F0-9]{24})?$`)
@@ -97,13 +99,91 @@ func cleanupCallerOwnsLiveImage(callerImage string, liveImage *string) bool {
 	return liveImage != nil && strings.TrimSpace(callerImage) != "" && strings.TrimSpace(callerImage) == strings.TrimSpace(*liveImage)
 }
 
+func revisionImageAliases(deploymentID, branch, commitSHA, registryURL string) []string {
+	commitSHA = strings.TrimSpace(commitSHA)
+	if !isGitHubCommitSHA(commitSHA) {
+		return nil
+	}
+	localImage := fmt.Sprintf("obiente/%s:%s", deploymentID, dockerBuildImageTag(branch, commitSHA))
+	aliases := []string{localImage}
+	if parsed, err := url.Parse(registryURL); err == nil && parsed.Host != "" {
+		aliases = append(aliases, parsed.Host+"/"+localImage)
+	}
+	return aliases
+}
+
+func activeRevisionImages(builds []*database.BuildHistory, deploymentID, registryURL string) map[string]struct{} {
+	protected := make(map[string]struct{})
+	for _, build := range builds {
+		if build.Status != int32(deploymentsv1.BuildStatus_BUILD_PENDING) &&
+			build.Status != int32(deploymentsv1.BuildStatus_BUILD_BUILDING) {
+			continue
+		}
+		if build.ImageName != nil {
+			for _, image := range localImageAliases(registryURL, strings.TrimSpace(*build.ImageName)) {
+				if image != "" {
+					protected[image] = struct{}{}
+				}
+			}
+		}
+		if build.CommitSHA != nil {
+			for _, image := range revisionImageAliases(deploymentID, build.Branch, *build.CommitSHA, registryURL) {
+				protected[image] = struct{}{}
+			}
+		}
+	}
+	return protected
+}
+
+func (s *Service) currentRevisionImageReservations(ctx context.Context, deploymentID, organizationID, registryURL string) (map[string]struct{}, bool, error) {
+	var builds []*database.BuildHistory
+	if err := database.DB.WithContext(ctx).
+		Where("deployment_id = ? AND organization_id = ? AND status IN ?", deploymentID, organizationID, []int32{
+			int32(deploymentsv1.BuildStatus_BUILD_PENDING),
+			int32(deploymentsv1.BuildStatus_BUILD_BUILDING),
+		}).
+		Find(&builds).Error; err != nil {
+		return nil, false, err
+	}
+	protected := activeRevisionImages(builds, deploymentID, registryURL)
+
+	// A queued preview head is reserved before TriggerDeployment creates its
+	// build-history row. Protect both the queued head and the currently active
+	// head so force-pushing back to an older SHA cannot race image cleanup.
+	var preview database.PullRequestDeployment
+	previewErr := database.DB.WithContext(ctx).
+		Select("head_sha", "active_head_sha", "head_ref").
+		Where("preview_deployment_id = ? AND closed_at IS NULL", deploymentID).
+		First(&preview).Error
+	if previewErr == nil {
+		for _, commitSHA := range []string{preview.HeadSHA, stringValue(preview.ActiveHeadSHA)} {
+			for _, image := range revisionImageAliases(deploymentID, preview.HeadRef, commitSHA, registryURL) {
+				protected[image] = struct{}{}
+			}
+		}
+	} else if !errors.Is(previewErr, gorm.ErrRecordNotFound) {
+		return nil, false, previewErr
+	}
+
+	var control database.DeploymentBuildControl
+	controlErr := database.DB.WithContext(ctx).
+		Select("build_token", "cancel_requested_at").
+		Where("deployment_id = ?", deploymentID).
+		First(&control).Error
+	if controlErr != nil && !errors.Is(controlErr, gorm.ErrRecordNotFound) {
+		return nil, false, controlErr
+	}
+	activeLeaseWithoutRevision := controlErr == nil && control.BuildToken != "" && control.CancelRequestedAt == nil && len(protected) == 0
+	return protected, activeLeaseWithoutRevision, nil
+}
+
 func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentID, organizationID, callerImage string) {
 	// Read through the database instead of the deployment repository cache. A
 	// cleanup can be delayed while newer revisions finish, and only the actual
 	// live image may determine which preceding revision is rollback-safe.
 	var deployment database.Deployment
 	if err := database.DB.WithContext(ctx).
-		Select("image").
+		Select("image", "branch").
 		Where("id = ? AND deleted_at IS NULL", deploymentID).
 		First(&deployment).Error; err != nil {
 		logger.Warn("[ImageCleanup] Failed to read live image for deployment %s: %v", deploymentID, err)
@@ -130,6 +210,14 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 	client := &http.Client{Timeout: 15 * time.Second}
 	protectedDigests := make(map[string]map[string]struct{})
 	unsafeRepositories := make(map[string]struct{})
+	activeImages, activeUnknown, err := s.currentRevisionImageReservations(ctx, deploymentID, organizationID, registryURL)
+	if err != nil || activeUnknown {
+		logger.Warn("[ImageCleanup] Skipping cleanup for deployment %s because active revision ownership could not be established: %v", deploymentID, err)
+		return
+	}
+	for image := range activeImages {
+		kept[image] = struct{}{}
+	}
 	for image := range kept {
 		repository, tag, ok := splitRegistryImage(registryURL, image)
 		if !ok {
@@ -148,6 +236,15 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 	}
 
 	for _, image := range obsolete {
+		activeImages, activeUnknown, err = s.currentRevisionImageReservations(ctx, deploymentID, organizationID, registryURL)
+		if err != nil || activeUnknown {
+			logger.Warn("[ImageCleanup] Stopping cleanup for deployment %s because active revision ownership changed: %v", deploymentID, err)
+			return
+		}
+		if _, active := activeImages[image]; active {
+			logger.Info("[ImageCleanup] Retaining image %s because an active build owns its revision", image)
+			continue
+		}
 		if repository, tag, ok := splitRegistryImage(registryURL, image); ok {
 			if _, unsafe := unsafeRepositories[repository]; !unsafe {
 				digest, err := registryManifestDigest(ctx, client, registryURL, repository, tag)

--- a/apps/deployments-service/internal/service/image_cleanup.go
+++ b/apps/deployments-service/internal/service/image_cleanup.go
@@ -1,0 +1,213 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/obiente/cloud/apps/shared/pkg/database"
+	"github.com/obiente/cloud/apps/shared/pkg/logger"
+	"github.com/obiente/cloud/apps/shared/pkg/platform"
+)
+
+var revisionImageTagPattern = regexp.MustCompile(`-[a-fA-F0-9]{40}(?:[a-fA-F0-9]{24})?$`)
+
+const registryManifestAccept = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json"
+
+// retainedRevisionImages keeps the currently deployed image and one prior
+// successful image for rollback. Older build records remain available without
+// retaining every immutable image tag.
+func retainedRevisionImages(builds []*database.BuildHistory, currentImage string) (map[string]struct{}, []string) {
+	kept := make(map[string]struct{}, 2)
+	if currentImage = strings.TrimSpace(currentImage); currentImage != "" {
+		kept[currentImage] = struct{}{}
+	}
+	for _, build := range builds {
+		if build.Status != 3 || build.ImageName == nil {
+			continue
+		}
+		image := strings.TrimSpace(*build.ImageName)
+		if image == "" {
+			continue
+		}
+		kept[image] = struct{}{}
+		if len(kept) >= 2 {
+			break
+		}
+	}
+
+	obsoleteSet := make(map[string]struct{})
+	for _, build := range builds {
+		if build.ImageName == nil {
+			continue
+		}
+		image := strings.TrimSpace(*build.ImageName)
+		if !isRevisionTaggedImage(image) {
+			continue
+		}
+		if _, retain := kept[image]; !retain {
+			obsoleteSet[image] = struct{}{}
+		}
+	}
+
+	obsolete := make([]string, 0, len(obsoleteSet))
+	for image := range obsoleteSet {
+		obsolete = append(obsolete, image)
+	}
+	return kept, obsolete
+}
+
+func isRevisionTaggedImage(image string) bool {
+	lastSlash := strings.LastIndexByte(image, '/')
+	lastColon := strings.LastIndexByte(image, ':')
+	return lastColon > lastSlash && revisionImageTagPattern.MatchString(image[lastColon+1:])
+}
+
+func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentID, organizationID, currentImage string) {
+	builds, _, err := s.buildHistoryRepo.ListBuilds(ctx, deploymentID, organizationID, 0, 0)
+	if err != nil {
+		logger.Warn("[ImageCleanup] Failed to list build images for deployment %s: %v", deploymentID, err)
+		return
+	}
+
+	kept, obsolete := retainedRevisionImages(builds, currentImage)
+	if len(obsolete) == 0 {
+		return
+	}
+
+	registryURL := platform.RegistryURL()
+	client := &http.Client{Timeout: 15 * time.Second}
+	protectedDigests := make(map[string]map[string]struct{})
+	unsafeRepositories := make(map[string]struct{})
+	for image := range kept {
+		repository, tag, ok := splitRegistryImage(registryURL, image)
+		if !ok {
+			continue
+		}
+		digest, err := registryManifestDigest(ctx, client, registryURL, repository, tag)
+		if err != nil {
+			unsafeRepositories[repository] = struct{}{}
+			logger.Warn("[ImageCleanup] Keeping registry repository %s unchanged because protected image %s could not be resolved: %v", repository, image, err)
+			continue
+		}
+		if protectedDigests[repository] == nil {
+			protectedDigests[repository] = make(map[string]struct{})
+		}
+		protectedDigests[repository][digest] = struct{}{}
+	}
+
+	for _, image := range obsolete {
+		if repository, tag, ok := splitRegistryImage(registryURL, image); ok {
+			if _, unsafe := unsafeRepositories[repository]; !unsafe {
+				digest, err := registryManifestDigest(ctx, client, registryURL, repository, tag)
+				if err != nil {
+					logger.Warn("[ImageCleanup] Failed to resolve obsolete registry image %s: %v", image, err)
+				} else if _, protected := protectedDigests[repository][digest]; protected {
+					logger.Info("[ImageCleanup] Retaining registry manifest %s because a rollback tag still references it", digest)
+				} else if err := deleteRegistryManifest(ctx, client, registryURL, repository, digest); err != nil {
+					logger.Warn("[ImageCleanup] Failed to delete obsolete registry image %s: %v", image, err)
+				} else {
+					logger.Info("[ImageCleanup] Deleted obsolete registry image %s", image)
+				}
+			}
+		}
+
+		for _, localImage := range localImageAliases(registryURL, image) {
+			if err := exec.CommandContext(ctx, "docker", "image", "rm", localImage).Run(); err != nil {
+				logger.Debug("[ImageCleanup] Could not remove local image tag %s: %v", localImage, err)
+			}
+		}
+	}
+}
+
+func splitRegistryImage(registryURL, image string) (repository, tag string, ok bool) {
+	parsed, err := url.Parse(registryURL)
+	if err != nil || parsed.Host == "" {
+		return "", "", false
+	}
+	prefix := parsed.Host + "/"
+	if !strings.HasPrefix(image, prefix) {
+		return "", "", false
+	}
+	reference := strings.TrimPrefix(image, prefix)
+	lastSlash := strings.LastIndexByte(reference, '/')
+	lastColon := strings.LastIndexByte(reference, ':')
+	if lastColon <= lastSlash || lastColon == len(reference)-1 {
+		return "", "", false
+	}
+	return reference[:lastColon], reference[lastColon+1:], true
+}
+
+func registryManifestDigest(ctx context.Context, client *http.Client, registryURL, repository, tag string) (string, error) {
+	req, err := registryRequest(ctx, http.MethodHead, registryURL, repository, tag)
+	if err != nil {
+		return "", err
+	}
+	response, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", fmt.Errorf("registry returned %s", response.Status)
+	}
+	digest := strings.TrimSpace(response.Header.Get("Docker-Content-Digest"))
+	if digest == "" {
+		return "", fmt.Errorf("registry response omitted Docker-Content-Digest")
+	}
+	return digest, nil
+}
+
+func deleteRegistryManifest(ctx context.Context, client *http.Client, registryURL, repository, digest string) error {
+	req, err := registryRequest(ctx, http.MethodDelete, registryURL, repository, digest)
+	if err != nil {
+		return err
+	}
+	response, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("registry returned %s", response.Status)
+	}
+	return nil
+}
+
+func registryRequest(ctx context.Context, method, registryURL, repository, reference string) (*http.Request, error) {
+	base := strings.TrimSuffix(registryURL, "/")
+	segments := strings.Split(repository, "/")
+	for index := range segments {
+		segments[index] = url.PathEscape(segments[index])
+	}
+	endpoint := fmt.Sprintf("%s/v2/%s/manifests/%s", base, strings.Join(segments, "/"), url.PathEscape(reference))
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", registryManifestAccept)
+	username := strings.TrimSpace(os.Getenv("REGISTRY_USERNAME"))
+	if username == "" {
+		username = "obiente"
+	}
+	if password := os.Getenv("REGISTRY_PASSWORD"); password != "" {
+		req.SetBasicAuth(username, password)
+	}
+	return req, nil
+}
+
+func localImageAliases(registryURL, image string) []string {
+	aliases := []string{image}
+	if parsed, err := url.Parse(registryURL); err == nil && parsed.Host != "" {
+		if local := strings.TrimPrefix(image, parsed.Host+"/"); local != image {
+			aliases = append(aliases, local)
+		}
+	}
+	return aliases
+}

--- a/apps/deployments-service/internal/service/image_cleanup.go
+++ b/apps/deployments-service/internal/service/image_cleanup.go
@@ -218,22 +218,7 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 	for image := range activeImages {
 		kept[image] = struct{}{}
 	}
-	for image := range kept {
-		repository, tag, ok := splitRegistryImage(registryURL, image)
-		if !ok {
-			continue
-		}
-		digest, err := registryManifestDigest(ctx, client, registryURL, repository, tag)
-		if err != nil {
-			unsafeRepositories[repository] = struct{}{}
-			logger.Warn("[ImageCleanup] Keeping registry repository %s unchanged because protected image %s could not be resolved: %v", repository, image, err)
-			continue
-		}
-		if protectedDigests[repository] == nil {
-			protectedDigests[repository] = make(map[string]struct{})
-		}
-		protectedDigests[repository][digest] = struct{}{}
-	}
+	protectRegistryImageDigests(ctx, client, registryURL, kept, protectedDigests, unsafeRepositories)
 
 	for _, image := range obsolete {
 		activeImages, activeUnknown, err = s.currentRevisionImageReservations(ctx, deploymentID, organizationID, registryURL)
@@ -245,6 +230,10 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 			logger.Info("[ImageCleanup] Retaining image %s because an active build owns its revision", image)
 			continue
 		}
+		// Registry manifest deletion is digest-wide: another active tag can
+		// point at the same output even when its revision name differs. Refresh
+		// active digests immediately before every deletion decision.
+		protectRegistryImageDigests(ctx, client, registryURL, activeImages, protectedDigests, unsafeRepositories)
 		if repository, tag, ok := splitRegistryImage(registryURL, image); ok {
 			if _, unsafe := unsafeRepositories[repository]; !unsafe {
 				digest, err := registryManifestDigest(ctx, client, registryURL, repository, tag)
@@ -265,6 +254,28 @@ func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentI
 				logger.Debug("[ImageCleanup] Could not remove local image tag %s: %v", localImage, err)
 			}
 		}
+	}
+}
+
+func protectRegistryImageDigests(ctx context.Context, client *http.Client, registryURL string, images map[string]struct{}, protectedDigests map[string]map[string]struct{}, unsafeRepositories map[string]struct{}) {
+	for image := range images {
+		repository, tag, ok := splitRegistryImage(registryURL, image)
+		if !ok {
+			continue
+		}
+		if _, unsafe := unsafeRepositories[repository]; unsafe {
+			continue
+		}
+		digest, err := registryManifestDigest(ctx, client, registryURL, repository, tag)
+		if err != nil {
+			unsafeRepositories[repository] = struct{}{}
+			logger.Warn("[ImageCleanup] Keeping registry repository %s unchanged because protected image %s could not be resolved: %v", repository, image, err)
+			continue
+		}
+		if protectedDigests[repository] == nil {
+			protectedDigests[repository] = make(map[string]struct{})
+		}
+		protectedDigests[repository][digest] = struct{}{}
 	}
 }
 

--- a/apps/deployments-service/internal/service/image_cleanup.go
+++ b/apps/deployments-service/internal/service/image_cleanup.go
@@ -93,7 +93,28 @@ func isRevisionTaggedImage(image string) bool {
 	return lastColon > lastSlash && revisionImageTagPattern.MatchString(image[lastColon+1:])
 }
 
-func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentID, organizationID, currentImage string) {
+func cleanupCallerOwnsLiveImage(callerImage string, liveImage *string) bool {
+	return liveImage != nil && strings.TrimSpace(callerImage) != "" && strings.TrimSpace(callerImage) == strings.TrimSpace(*liveImage)
+}
+
+func (s *Service) cleanupObsoleteRevisionImages(ctx context.Context, deploymentID, organizationID, callerImage string) {
+	// Read through the database instead of the deployment repository cache. A
+	// cleanup can be delayed while newer revisions finish, and only the actual
+	// live image may determine which preceding revision is rollback-safe.
+	var deployment database.Deployment
+	if err := database.DB.WithContext(ctx).
+		Select("image").
+		Where("id = ? AND deleted_at IS NULL", deploymentID).
+		First(&deployment).Error; err != nil {
+		logger.Warn("[ImageCleanup] Failed to read live image for deployment %s: %v", deploymentID, err)
+		return
+	}
+	if !cleanupCallerOwnsLiveImage(callerImage, deployment.Image) {
+		logger.Info("[ImageCleanup] Skipping stale cleanup for deployment %s because a newer image is live", deploymentID)
+		return
+	}
+	currentImage := strings.TrimSpace(*deployment.Image)
+
 	builds, _, err := s.buildHistoryRepo.ListBuilds(ctx, deploymentID, organizationID, 0, 0)
 	if err != nil {
 		logger.Warn("[ImageCleanup] Failed to list build images for deployment %s: %v", deploymentID, err)

--- a/apps/deployments-service/internal/service/image_cleanup_test.go
+++ b/apps/deployments-service/internal/service/image_cleanup_test.go
@@ -1,6 +1,9 @@
 package deployments
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -107,5 +110,37 @@ func TestActiveRevisionImagesProtectsCommitBeforeImageExists(t *testing.T) {
 		if _, ok := protected[image]; !ok {
 			t.Fatalf("active revision image %q was not protected", image)
 		}
+	}
+}
+
+func TestProtectRegistryImageDigestsIncludesNewActiveRevision(t *testing.T) {
+	const digest = "sha256:output-identical"
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", request.Method)
+		}
+		response.Header().Set("Docker-Content-Digest", digest)
+		response.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	registryHost := strings.TrimPrefix(server.URL, "http://")
+	activeImage := registryHost + "/obiente/deploy-1:main-" + strings.Repeat("b", 40)
+	protectedDigests := make(map[string]map[string]struct{})
+	unsafeRepositories := make(map[string]struct{})
+	protectRegistryImageDigests(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		map[string]struct{}{activeImage: {}},
+		protectedDigests,
+		unsafeRepositories,
+	)
+
+	if _, protected := protectedDigests["obiente/deploy-1"][digest]; !protected {
+		t.Fatalf("newly active manifest digest %q was not protected", digest)
+	}
+	if len(unsafeRepositories) != 0 {
+		t.Fatalf("unexpected unsafe repositories: %v", unsafeRepositories)
 	}
 }

--- a/apps/deployments-service/internal/service/image_cleanup_test.go
+++ b/apps/deployments-service/internal/service/image_cleanup_test.go
@@ -86,3 +86,26 @@ func TestCleanupCallerMustOwnLiveImage(t *testing.T) {
 		t.Fatalf("obsolete images = %v, want only delayed caller revision A", obsolete)
 	}
 }
+
+func TestActiveRevisionImagesProtectsCommitBeforeImageExists(t *testing.T) {
+	commitSHA := strings.Repeat("a", 40)
+	builds := []*database.BuildHistory{
+		{
+			Status:       2,
+			DeploymentID: "deploy-1",
+			Branch:       "feature/reused",
+			CommitSHA:    &commitSHA,
+			ImageName:    nil,
+		},
+	}
+	protected := activeRevisionImages(builds, "deploy-1", "https://registry.example:5000")
+	tag := dockerBuildImageTag("feature/reused", commitSHA)
+	for _, image := range []string{
+		"obiente/deploy-1:" + tag,
+		"registry.example:5000/obiente/deploy-1:" + tag,
+	} {
+		if _, ok := protected[image]; !ok {
+			t.Fatalf("active revision image %q was not protected", image)
+		}
+	}
+}

--- a/apps/deployments-service/internal/service/image_cleanup_test.go
+++ b/apps/deployments-service/internal/service/image_cleanup_test.go
@@ -2,12 +2,15 @@ package deployments
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/obiente/cloud/apps/shared/pkg/database"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestRetainedRevisionImagesKeepsCurrentAndRollback(t *testing.T) {
@@ -87,6 +90,40 @@ func TestCleanupCallerMustOwnLiveImage(t *testing.T) {
 	}
 	if len(obsolete) != 1 || obsolete[0] != revisionA {
 		t.Fatalf("obsolete images = %v, want only delayed caller revision A", obsolete)
+	}
+}
+
+func TestCurrentDeploymentImageReadsNewRollout(t *testing.T) {
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "-"))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	if err := db.AutoMigrate(&database.Deployment{}); err != nil {
+		t.Fatalf("migrate sqlite db: %v", err)
+	}
+	previousDB := database.DB
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+
+	revisionA := "registry.example/obiente/deploy-1:main-" + strings.Repeat("a", 40)
+	revisionB := "registry.example/obiente/deploy-1:main-" + strings.Repeat("b", 40)
+	if err := db.Create(&database.Deployment{ID: "deploy-1", Image: &revisionA}).Error; err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+	if err := db.Model(&database.Deployment{}).Where("id = ?", "deploy-1").Update("image", revisionB).Error; err != nil {
+		t.Fatalf("update deployment image: %v", err)
+	}
+
+	liveImage, err := currentDeploymentImage(context.Background(), "deploy-1")
+	if err != nil {
+		t.Fatalf("read current deployment image: %v", err)
+	}
+	if cleanupCallerOwnsLiveImage(revisionA, liveImage) {
+		t.Fatal("stale cleanup still owned the image after a newer rollout completed")
+	}
+	if !cleanupCallerOwnsLiveImage(revisionB, liveImage) {
+		t.Fatalf("live image = %v, want revision B", liveImage)
 	}
 }
 

--- a/apps/deployments-service/internal/service/image_cleanup_test.go
+++ b/apps/deployments-service/internal/service/image_cleanup_test.go
@@ -12,9 +12,14 @@ func TestRetainedRevisionImagesKeepsCurrentAndRollback(t *testing.T) {
 	previous := "registry.example/obiente/deploy-1:main-" + strings.Repeat("b", 40)
 	old := "registry.example/obiente/deploy-1:main-" + strings.Repeat("a", 40)
 	failed := "registry.example/obiente/deploy-1:main-" + strings.Repeat("d", 64)
+	active := "registry.example/obiente/deploy-1:main-" + strings.Repeat("e", 40)
+	runtimeFailed := "registry.example/obiente/deploy-1:main-" + strings.Repeat("f", 40)
 	manual := "registry.example/obiente/deploy-1:main"
+	runtimeError := "container startup failed"
 	builds := []*database.BuildHistory{
+		{Status: 2, ImageName: &active},
 		{Status: 4, ImageName: &failed},
+		{Status: 3, ImageName: &runtimeFailed, Error: &runtimeError},
 		{Status: 3, ImageName: &current},
 		{Status: 3, ImageName: &previous},
 		{Status: 3, ImageName: &old},
@@ -28,7 +33,13 @@ func TestRetainedRevisionImagesKeepsCurrentAndRollback(t *testing.T) {
 	if _, ok := kept[previous]; !ok {
 		t.Fatal("rollback image was not retained")
 	}
-	wantObsolete := map[string]bool{old: true, failed: true}
+	if _, ok := kept[active]; !ok {
+		t.Fatal("active build image was not retained")
+	}
+	if _, ok := kept[manual]; !ok {
+		t.Fatal("stable mutable tag was not retained")
+	}
+	wantObsolete := map[string]bool{old: true, failed: true, runtimeFailed: true}
 	if len(obsolete) != len(wantObsolete) {
 		t.Fatalf("obsolete images = %v, want %v", obsolete, wantObsolete)
 	}

--- a/apps/deployments-service/internal/service/image_cleanup_test.go
+++ b/apps/deployments-service/internal/service/image_cleanup_test.go
@@ -57,3 +57,32 @@ func TestSplitRegistryImage(t *testing.T) {
 		t.Fatalf("unexpected registry image split: repository=%q tag=%q ok=%v", repository, tag, ok)
 	}
 }
+
+func TestCleanupCallerMustOwnLiveImage(t *testing.T) {
+	revisionA := "registry.example/obiente/deploy-1:main-" + strings.Repeat("a", 40)
+	revisionB := "registry.example/obiente/deploy-1:main-" + strings.Repeat("b", 40)
+	revisionC := "registry.example/obiente/deploy-1:main-" + strings.Repeat("c", 40)
+
+	if cleanupCallerOwnsLiveImage(revisionA, &revisionC) {
+		t.Fatal("delayed cleanup for revision A accepted newer live revision C")
+	}
+	if !cleanupCallerOwnsLiveImage("  "+revisionC+"  ", &revisionC) {
+		t.Fatal("cleanup for the live revision was rejected")
+	}
+	if cleanupCallerOwnsLiveImage(revisionC, nil) {
+		t.Fatal("cleanup without a live deployment image was accepted")
+	}
+
+	builds := []*database.BuildHistory{
+		{Status: 3, ImageName: &revisionC},
+		{Status: 3, ImageName: &revisionB},
+		{Status: 3, ImageName: &revisionA},
+	}
+	kept, obsolete := retainedRevisionImages(builds, revisionC)
+	if _, ok := kept[revisionB]; !ok {
+		t.Fatal("live revision C did not retain revision B for rollback")
+	}
+	if len(obsolete) != 1 || obsolete[0] != revisionA {
+		t.Fatalf("obsolete images = %v, want only delayed caller revision A", obsolete)
+	}
+}

--- a/apps/deployments-service/internal/service/image_cleanup_test.go
+++ b/apps/deployments-service/internal/service/image_cleanup_test.go
@@ -1,0 +1,48 @@
+package deployments
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/obiente/cloud/apps/shared/pkg/database"
+)
+
+func TestRetainedRevisionImagesKeepsCurrentAndRollback(t *testing.T) {
+	current := "registry.example/obiente/deploy-1:main-" + strings.Repeat("c", 40)
+	previous := "registry.example/obiente/deploy-1:main-" + strings.Repeat("b", 40)
+	old := "registry.example/obiente/deploy-1:main-" + strings.Repeat("a", 40)
+	failed := "registry.example/obiente/deploy-1:main-" + strings.Repeat("d", 64)
+	manual := "registry.example/obiente/deploy-1:main"
+	builds := []*database.BuildHistory{
+		{Status: 4, ImageName: &failed},
+		{Status: 3, ImageName: &current},
+		{Status: 3, ImageName: &previous},
+		{Status: 3, ImageName: &old},
+		{Status: 3, ImageName: &manual},
+	}
+
+	kept, obsolete := retainedRevisionImages(builds, current)
+	if _, ok := kept[current]; !ok {
+		t.Fatal("current image was not retained")
+	}
+	if _, ok := kept[previous]; !ok {
+		t.Fatal("rollback image was not retained")
+	}
+	wantObsolete := map[string]bool{old: true, failed: true}
+	if len(obsolete) != len(wantObsolete) {
+		t.Fatalf("obsolete images = %v, want %v", obsolete, wantObsolete)
+	}
+	for _, image := range obsolete {
+		if !wantObsolete[image] {
+			t.Fatalf("unexpected obsolete image %q", image)
+		}
+	}
+}
+
+func TestSplitRegistryImage(t *testing.T) {
+	image := "registry.example:5000/obiente/deploy-1:feature-" + strings.Repeat("a", 64)
+	repository, tag, ok := splitRegistryImage("https://registry.example:5000", image)
+	if !ok || repository != "obiente/deploy-1" || tag != strings.TrimPrefix(image, "registry.example:5000/obiente/deploy-1:") {
+		t.Fatalf("unexpected registry image split: repository=%q tag=%q ok=%v", repository, tag, ok)
+	}
+}

--- a/apps/deployments-service/internal/service/image_tag_test.go
+++ b/apps/deployments-service/internal/service/image_tag_test.go
@@ -46,6 +46,12 @@ func TestDockerBuildImageTagIncludesExactRevision(t *testing.T) {
 	if len(longTag) > 128 || !strings.HasSuffix(longTag, "-"+first) || !valid.MatchString(longTag) {
 		t.Fatalf("long revision tag is invalid: %q", longTag)
 	}
+
+	sha256Revision := strings.Repeat("C", 64)
+	sha256Tag := dockerBuildImageTag(strings.Repeat("feature/", 40), sha256Revision)
+	if len(sha256Tag) > 128 || !strings.HasSuffix(sha256Tag, "-"+strings.ToLower(sha256Revision)) || !valid.MatchString(sha256Tag) {
+		t.Fatalf("64-character revision tag is invalid: %q", sha256Tag)
+	}
 }
 
 func TestDockerBuildImageTagKeepsManualBuildTagsStable(t *testing.T) {

--- a/apps/deployments-service/internal/service/image_tag_test.go
+++ b/apps/deployments-service/internal/service/image_tag_test.go
@@ -62,3 +62,13 @@ func TestDockerBuildImageTagKeepsManualBuildTagsStable(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldRemoveIntermediateImageProtectsFallbackFinalImage(t *testing.T) {
+	finalImage := "obiente/deploy-1:main-" + strings.Repeat("a", 40)
+	if shouldRemoveIntermediateImage(finalImage, finalImage) {
+		t.Fatal("fallback image sharing the final tag was marked for removal")
+	}
+	if !shouldRemoveIntermediateImage("obiente/deploy-1-railpack:main", finalImage) {
+		t.Fatal("distinct intermediate image was not marked for removal")
+	}
+}

--- a/apps/deployments-service/internal/service/image_tag_test.go
+++ b/apps/deployments-service/internal/service/image_tag_test.go
@@ -29,3 +29,30 @@ func TestDockerImageTagSanitizesGitRefsDeterministically(t *testing.T) {
 		t.Fatalf("long ref produced invalid Docker tag %q", long)
 	}
 }
+
+func TestDockerBuildImageTagIncludesExactRevision(t *testing.T) {
+	first := strings.Repeat("a", 40)
+	second := strings.Repeat("b", 40)
+	firstTag := dockerBuildImageTag("feat/preview", first)
+	secondTag := dockerBuildImageTag("feat/preview", second)
+	valid := regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
+	if firstTag == secondTag {
+		t.Fatal("different revisions reused the same Docker tag")
+	}
+	if !strings.HasSuffix(firstTag, "-"+first) || !valid.MatchString(firstTag) {
+		t.Fatalf("revision tag is invalid or does not retain the commit: %q", firstTag)
+	}
+	longTag := dockerBuildImageTag(strings.Repeat("feature/", 40), strings.ToUpper(first))
+	if len(longTag) > 128 || !strings.HasSuffix(longTag, "-"+first) || !valid.MatchString(longTag) {
+		t.Fatalf("long revision tag is invalid: %q", longTag)
+	}
+}
+
+func TestDockerBuildImageTagKeepsManualBuildTagsStable(t *testing.T) {
+	want := dockerImageTag("main")
+	for _, commit := range []string{"", "not-a-commit", strings.Repeat("a", 39)} {
+		if got := dockerBuildImageTag("main", commit); got != want {
+			t.Fatalf("manual build tag changed for commit %q: got %q, want %q", commit, got, want)
+		}
+	}
+}

--- a/apps/deployments-service/internal/service/lifecycle.go
+++ b/apps/deployments-service/internal/service/lifecycle.go
@@ -125,7 +125,12 @@ func (s *Service) TriggerDeployment(ctx context.Context, req *connect.Request[de
 	// Start async rebuild with log streaming
 	go func() {
 		defer buildCancel()
-		defer s.unregisterDeploymentBuild(deploymentID, buildToken)
+		buildLeaseReleased := false
+		defer func() {
+			if !buildLeaseReleased {
+				s.unregisterDeploymentBuild(deploymentID, buildToken)
+			}
+		}()
 		buildCtx = orchestrator.WithTargetNode(buildCtx, targetNodeID)
 
 		// Recover from panics to ensure deployment status is always updated
@@ -736,9 +741,17 @@ func (s *Service) TriggerDeployment(ctx context.Context, req *connect.Request[de
 
 			_ = s.repo.UpdateStatus(buildCtx, deploymentID, int32(deploymentsv1.DeploymentStatus_RUNNING))
 			previewStatusFinalized = true
-			s.updatePullRequestDeploymentRuntime(buildCtx, deploymentID, commitSHA, deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING, "")
+
+			// A terminal preview update may immediately queue the next revision.
+			// Release this build's lease first so that trigger can claim it while
+			// image cleanup continues on a detached context.
+			s.unregisterDeploymentBuild(deploymentID, buildToken)
+			buildLeaseReleased = true
+			completionCtx, completionCancel := s.detachedContext(2 * time.Minute)
+			defer completionCancel()
+			s.updatePullRequestDeploymentRuntime(completionCtx, deploymentID, commitSHA, deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING, "")
 			if buildResult != nil && buildResult.ImageName != "" {
-				s.cleanupObsoleteRevisionImages(buildCtx, deploymentID, dbDeployment.OrganizationID, buildResult.ImageName)
+				s.cleanupObsoleteRevisionImages(completionCtx, deploymentID, dbDeployment.OrganizationID, buildResult.ImageName)
 			}
 		}
 	}()

--- a/apps/deployments-service/internal/service/lifecycle.go
+++ b/apps/deployments-service/internal/service/lifecycle.go
@@ -737,6 +737,9 @@ func (s *Service) TriggerDeployment(ctx context.Context, req *connect.Request[de
 			_ = s.repo.UpdateStatus(buildCtx, deploymentID, int32(deploymentsv1.DeploymentStatus_RUNNING))
 			previewStatusFinalized = true
 			s.updatePullRequestDeploymentRuntime(buildCtx, deploymentID, commitSHA, deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING, "")
+			if buildResult != nil && buildResult.ImageName != "" {
+				s.cleanupObsoleteRevisionImages(buildCtx, deploymentID, dbDeployment.OrganizationID, buildResult.ImageName)
+			}
 		}
 	}()
 

--- a/apps/deployments-service/internal/service/lifecycle.go
+++ b/apps/deployments-service/internal/service/lifecycle.go
@@ -745,10 +745,13 @@ func (s *Service) TriggerDeployment(ctx context.Context, req *connect.Request[de
 			// A terminal preview update may immediately queue the next revision.
 			// Release this build's lease first so that trigger can claim it while
 			// image cleanup continues on a detached context.
-			s.unregisterDeploymentBuild(deploymentID, buildToken)
-			buildLeaseReleased = true
 			completionCtx, completionCancel := s.detachedContext(2 * time.Minute)
 			defer completionCancel()
+			if !s.waitForDeploymentBuildRelease(completionCtx, deploymentID, buildToken) {
+				logger.Warn("[TriggerDeployment] Timed out releasing the completed build lease for %s", deploymentID)
+				return
+			}
+			buildLeaseReleased = true
 			s.updatePullRequestDeploymentRuntime(completionCtx, deploymentID, commitSHA, deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING, "")
 			if buildResult != nil && buildResult.ImageName != "" {
 				s.cleanupObsoleteRevisionImages(completionCtx, deploymentID, dbDeployment.OrganizationID, buildResult.ImageName)

--- a/apps/deployments-service/internal/service/lifecycle.go
+++ b/apps/deployments-service/internal/service/lifecycle.go
@@ -745,13 +745,20 @@ func (s *Service) TriggerDeployment(ctx context.Context, req *connect.Request[de
 			// A terminal preview update may immediately queue the next revision.
 			// Release this build's lease first so that trigger can claim it while
 			// image cleanup continues on a detached context.
-			completionCtx, completionCancel := s.detachedContext(2 * time.Minute)
-			defer completionCancel()
-			if !s.waitForDeploymentBuildRelease(completionCtx, deploymentID, buildToken) {
-				logger.Warn("[TriggerDeployment] Timed out releasing the completed build lease for %s", deploymentID)
+			initialReleaseCtx, initialReleaseCancel := s.detachedContext(2 * time.Minute)
+			continuationCtx, continuationCancel := s.detachedContext(0)
+			released := waitForDeploymentBuildReleaseWithContinuation(initialReleaseCtx, continuationCtx, func(ctx context.Context) bool {
+				return s.waitForDeploymentBuildRelease(ctx, deploymentID, buildToken)
+			})
+			initialReleaseCancel()
+			continuationCancel()
+			if !released {
+				logger.Warn("[TriggerDeployment] Stopped waiting to release the completed build lease for %s because the service is shutting down", deploymentID)
 				return
 			}
 			buildLeaseReleased = true
+			completionCtx, completionCancel := s.detachedContext(2 * time.Minute)
+			defer completionCancel()
 			s.updatePullRequestDeploymentRuntime(completionCtx, deploymentID, commitSHA, deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING, "")
 			if buildResult != nil && buildResult.ImageName != "" {
 				s.cleanupObsoleteRevisionImages(completionCtx, deploymentID, dbDeployment.OrganizationID, buildResult.ImageName)
@@ -764,6 +771,14 @@ func (s *Service) TriggerDeployment(ctx context.Context, req *connect.Request[de
 		Status:       "DEPLOYING",
 	})
 	return res, nil
+}
+
+func waitForDeploymentBuildReleaseWithContinuation(initialCtx, continuationCtx context.Context, waitForRelease func(context.Context) bool) bool {
+	if waitForRelease(initialCtx) {
+		return true
+	}
+	logger.Warn("[TriggerDeployment] Initial completed build lease release window elapsed; continuing release retries in the background")
+	return waitForRelease(continuationCtx)
 }
 
 func (s *Service) finalizeInterruptedBuildHistory(buildID string, startedAt time.Time) {

--- a/apps/deployments-service/internal/service/lifecycle_release_test.go
+++ b/apps/deployments-service/internal/service/lifecycle_release_test.go
@@ -1,0 +1,35 @@
+package deployments
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWaitForDeploymentBuildReleaseContinuesAfterInitialTimeout(t *testing.T) {
+	initialCtx, initialCancel := context.WithCancel(context.Background())
+	initialCancel()
+	continuationCtx, continuationCancel := context.WithCancel(context.Background())
+	defer continuationCancel()
+
+	attempts := 0
+	released := waitForDeploymentBuildReleaseWithContinuation(initialCtx, continuationCtx, func(ctx context.Context) bool {
+		attempts++
+		if attempts == 1 {
+			if ctx.Err() == nil {
+				t.Fatal("initial release attempt did not receive its expired context")
+			}
+			return false
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("continuation release context was already canceled: %v", ctx.Err())
+		}
+		return true
+	})
+
+	if !released {
+		t.Fatal("release did not continue to a successful retry")
+	}
+	if attempts != 2 {
+		t.Fatalf("release attempts = %d, want 2", attempts)
+	}
+}

--- a/apps/deployments-service/internal/service/lifecycle_trigger_test.go
+++ b/apps/deployments-service/internal/service/lifecycle_trigger_test.go
@@ -53,6 +53,35 @@ func TestInterruptedBuildHistoryIsFinalizedWithDetachedContext(t *testing.T) {
 	}
 }
 
+func TestUnregisterDeploymentBuildConfirmsDurableRelease(t *testing.T) {
+	db := newDeploymentServiceTestDB(t)
+	service := NewService(context.Background(), database.NewDeploymentRepository(db, nil), nil, nil)
+	control := database.DeploymentBuildControl{
+		DeploymentID: "deployment-complete",
+		BuildToken:   "completed-token",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := db.Create(&control).Error; err != nil {
+		t.Fatalf("seed build lease: %v", err)
+	}
+	service.activeBuilds[control.DeploymentID] = activeDeploymentBuild{token: control.BuildToken}
+
+	if !service.unregisterDeploymentBuild(control.DeploymentID, control.BuildToken) {
+		t.Fatal("completed build lease was not confirmed released")
+	}
+	var count int64
+	if err := db.Model(&database.DeploymentBuildControl{}).Where("deployment_id = ?", control.DeploymentID).Count(&count).Error; err != nil {
+		t.Fatalf("count build leases: %v", err)
+	}
+	if count != 0 {
+		t.Fatal("completed build lease remained durable after confirmed release")
+	}
+	if _, active := service.activeBuilds[control.DeploymentID]; active {
+		t.Fatal("completed build lease remained active in memory")
+	}
+}
+
 func TestRequestedDeploymentCommitSHARequiresSystemPrincipal(t *testing.T) {
 	commitSHA := strings.Repeat("a", 40)
 

--- a/apps/deployments-service/internal/service/service.go
+++ b/apps/deployments-service/internal/service/service.go
@@ -32,6 +32,7 @@ const (
 	deploymentBuildHeartbeatInterval  = 15 * time.Second
 	deploymentBuildHeartbeatTimeout   = 2 * time.Minute
 	deploymentBuildLegacyOwnerTimeout = 6 * time.Hour
+	deploymentBuildReleaseRetryDelay  = 250 * time.Millisecond
 )
 
 func deploymentBuildControlIsStale(control *database.DeploymentBuildControl, now time.Time) bool {
@@ -141,30 +142,61 @@ func (s *Service) registerDeploymentBuild(ctx context.Context, deploymentID stri
 	return token, nil
 }
 
-func (s *Service) unregisterDeploymentBuild(deploymentID, token string) {
+func (s *Service) unregisterDeploymentBuild(deploymentID, token string) bool {
 	s.activeBuildsMu.Lock()
 	if current, ok := s.activeBuilds[deploymentID]; ok && current.token == token {
 		delete(s.activeBuilds, deploymentID)
 	}
 	s.activeBuildsMu.Unlock()
 	if token == "" {
-		return
+		return true
 	}
 
 	ctx, cancel := s.detachedContext(10 * time.Second)
 	defer cancel()
-	_ = withDistributedLock(ctx, "deployment-build:"+deploymentID, func() error {
+	released := false
+	err := withDistributedLock(ctx, "deployment-build:"+deploymentID, func() error {
 		var control database.DeploymentBuildControl
-		if err := database.DB.WithContext(ctx).Where("deployment_id = ? AND build_token = ?", deploymentID, token).First(&control).Error; err != nil {
+		if err := database.DB.WithContext(ctx).Where("deployment_id = ? AND build_token = ?", deploymentID, token).First(&control).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+			released = true
 			return nil
+		} else if err != nil {
+			return err
 		}
+		var result *gorm.DB
 		if control.CancelRequestedAt != nil {
-			return database.DB.WithContext(ctx).Model(&control).Updates(map[string]interface{}{
+			result = database.DB.WithContext(ctx).Model(&control).Updates(map[string]interface{}{
 				"build_token": "", "owner_node_id": "", "heartbeat_at": nil, "updated_at": time.Now(),
-			}).Error
+			})
+		} else {
+			result = database.DB.WithContext(ctx).Delete(&control)
 		}
-		return database.DB.WithContext(ctx).Delete(&control).Error
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return fmt.Errorf("build lease release changed %d rows", result.RowsAffected)
+		}
+		released = true
+		return nil
 	})
+	if err != nil {
+		logger.Debug("[Deployments] Build lease release for %s will be retried: %v", deploymentID, err)
+	}
+	return err == nil && released
+}
+
+func (s *Service) waitForDeploymentBuildRelease(ctx context.Context, deploymentID, token string) bool {
+	for {
+		if s.unregisterDeploymentBuild(deploymentID, token) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(deploymentBuildReleaseRetryDelay):
+		}
+	}
 }
 
 func (s *Service) cancelDeploymentBuild(deploymentID string) error {

--- a/apps/deployments-service/internal/service/strategies.go
+++ b/apps/deployments-service/internal/service/strategies.go
@@ -80,6 +80,10 @@ func dockerBuildImageTag(ref, commitSHA string) string {
 	return base + "-" + commitSHA
 }
 
+func shouldRemoveIntermediateImage(intermediateImage, finalImage string) bool {
+	return intermediateImage != "" && intermediateImage != finalImage
+}
+
 func NewRailpackStrategy() *RailpackStrategy {
 	return &RailpackStrategy{}
 }
@@ -2391,8 +2395,12 @@ func (s *StaticStrategy) Build(ctx context.Context, deployment *database.Deploym
 
 	// The Railpack image is only an intermediate stage. Keeping its immutable
 	// revision tag would double local image retention for every static build.
-	if err := exec.CommandContext(ctx, "docker", "image", "rm", railpackImageName).Run(); err != nil {
-		writeBuildLog("⚠️  Could not remove intermediate Railpack image %s: %v", railpackImageName, err)
+	// The fallback builder can reuse the final name; in that case the final
+	// build has already replaced the intermediate tag and it must stay intact.
+	if shouldRemoveIntermediateImage(railpackImageName, finalImageName) {
+		if err := exec.CommandContext(ctx, "docker", "image", "rm", railpackImageName).Run(); err != nil {
+			writeBuildLog("⚠️  Could not remove intermediate Railpack image %s: %v", railpackImageName, err)
+		}
 	}
 
 	// Nginx always uses port 80

--- a/apps/deployments-service/internal/service/strategies.go
+++ b/apps/deployments-service/internal/service/strategies.go
@@ -28,6 +28,7 @@ import (
 type RailpackStrategy struct{}
 
 var dockerTagPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
+var gitCommitPattern = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
 
 // dockerImageTag keeps ordinary branch tags stable while converting refs such
 // as feat/example into a deterministic, collision-resistant Docker tag.
@@ -59,6 +60,25 @@ func dockerImageTag(ref string) string {
 		base = strings.TrimRight(base[:maxBaseLength], ".-")
 	}
 	return base + "-" + digest
+}
+
+// dockerBuildImageTag gives exact-revision builds an immutable image reference.
+// Reusing a branch-only tag can leave an orchestrator service unchanged even
+// after a newer commit was built and pushed under that same tag.
+func dockerBuildImageTag(ref, commitSHA string) string {
+	base := dockerImageTag(ref)
+	commitSHA = strings.ToLower(strings.TrimSpace(commitSHA))
+	if !gitCommitPattern.MatchString(commitSHA) {
+		return base
+	}
+	const maxBaseLength = 128 - 1 - 40
+	if len(base) > maxBaseLength {
+		base = strings.TrimRight(base[:maxBaseLength], ".-")
+	}
+	if base == "" {
+		base = "ref"
+	}
+	return base + "-" + commitSHA
 }
 
 func NewRailpackStrategy() *RailpackStrategy {
@@ -195,7 +215,7 @@ func (s *RailpackStrategy) Build(ctx context.Context, deployment *database.Deplo
 	}
 	writeBuildLog("   ✅ Repository cloned successfully")
 
-	imageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerImageTag(deployment.Branch))
+	imageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerBuildImageTag(deployment.Branch, config.CommitSHA))
 
 	// Determine build working directory (default to repo root)
 	buildWorkDir := buildDir
@@ -945,7 +965,7 @@ func (s *NixpacksStrategy) Build(ctx context.Context, deployment *database.Deplo
 	}
 	writeBuildLog("   ✅ Repository cloned successfully")
 
-	imageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerImageTag(deployment.Branch))
+	imageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerBuildImageTag(deployment.Branch, config.CommitSHA))
 
 	// Determine build working directory (default to repo root)
 	buildWorkDir := buildDir
@@ -1766,7 +1786,7 @@ func (s *DockerfileStrategy) Build(ctx context.Context, deployment *database.Dep
 		return &BuildResult{Success: false, Error: err}, err
 	}
 
-	imageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerImageTag(deployment.Branch))
+	imageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerBuildImageTag(deployment.Branch, config.CommitSHA))
 
 	// Use configured Dockerfile path or default to "Dockerfile"
 	dockerfile := config.DockerfilePath
@@ -2125,7 +2145,7 @@ func (s *StaticStrategy) Build(ctx context.Context, deployment *database.Deploym
 
 	// Step 1: Use Railpack to build the application
 	// This will create an image with all dependencies and built files
-	railpackImageName := fmt.Sprintf("obiente/%s-railpack:%s", deployment.ID, dockerImageTag(deployment.Branch))
+	railpackImageName := fmt.Sprintf("obiente/%s-railpack:%s", deployment.ID, dockerBuildImageTag(deployment.Branch, config.CommitSHA))
 
 	writeBuildLog := func(format string, args ...interface{}) {
 		msg := fmt.Sprintf(format, args...)
@@ -2361,7 +2381,7 @@ func (s *StaticStrategy) Build(ctx context.Context, deployment *database.Deploym
 		return &BuildResult{Success: false, Error: fmt.Errorf("failed to write Dockerfile: %w", err)}, nil
 	}
 
-	finalImageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerImageTag(deployment.Branch))
+	finalImageName := fmt.Sprintf("obiente/%s:%s", deployment.ID, dockerBuildImageTag(deployment.Branch, config.CommitSHA))
 
 	// Build final minimal nginx image
 	if err := buildDockerImage(ctx, buildDir, finalImageName, ".obiente.Dockerfile", nil, DockerfileBuildOptions{}, config.LogWriter, config.LogWriterErr); err != nil {

--- a/apps/deployments-service/internal/service/strategies.go
+++ b/apps/deployments-service/internal/service/strategies.go
@@ -28,7 +28,6 @@ import (
 type RailpackStrategy struct{}
 
 var dockerTagPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
-var gitCommitPattern = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
 
 // dockerImageTag keeps ordinary branch tags stable while converting refs such
 // as feat/example into a deterministic, collision-resistant Docker tag.
@@ -68,10 +67,10 @@ func dockerImageTag(ref string) string {
 func dockerBuildImageTag(ref, commitSHA string) string {
 	base := dockerImageTag(ref)
 	commitSHA = strings.ToLower(strings.TrimSpace(commitSHA))
-	if !gitCommitPattern.MatchString(commitSHA) {
+	if !isGitHubCommitSHA(commitSHA) {
 		return base
 	}
-	const maxBaseLength = 128 - 1 - 40
+	maxBaseLength := 128 - 1 - len(commitSHA)
 	if len(base) > maxBaseLength {
 		base = strings.TrimRight(base[:maxBaseLength], ".-")
 	}
@@ -2390,8 +2389,11 @@ func (s *StaticStrategy) Build(ctx context.Context, deployment *database.Deploym
 
 	writeBuildLog("✅ Created minimal nginx image")
 
-	// Clean up Railpack image (optional - we could keep it for caching)
-	// exec.CommandContext(ctx, "docker", "rmi", railpackImageName).Run()
+	// The Railpack image is only an intermediate stage. Keeping its immutable
+	// revision tag would double local image retention for every static build.
+	if err := exec.CommandContext(ctx, "docker", "image", "rm", railpackImageName).Run(); err != nil {
+		writeBuildLog("⚠️  Could not remove intermediate Railpack image %s: %v", railpackImageName, err)
+	}
 
 	// Nginx always uses port 80
 	port := 80


### PR DESCRIPTION
## Outcome

Exact-revision deployments now receive immutable Docker tags containing the validated commit SHA. Updating a pull request on the same branch therefore changes the Swarm service image reference and rolls out the newly checked revision instead of leaving an older healthy container online.

Railpack, Nixpacks, Dockerfile, and Static builds share the same rule. Manual builds without a valid exact revision retain their existing branch-based tags.

Closes #37

## Validation

- `go test -count=1 ./internal/service -run 'TestDocker(ImageTag|BuildImageTag)'`
- `go test -run '^$' ./...`
- `git diff --check`
- Attempted `pnpm nx test deployments-service`; the target did not start because it hard-codes the unavailable path `/usr/local/go/bin/go`.
- The full direct service suite reaches unrelated existing database-fixture failures. Representative failures reproduce unchanged on `origin/main` (`TestDeploymentServiceTenantIsolation` and `TestDisablingPullRequestConfigDetachesExistingRuntime`).