### PR TITLE
fix(deployments): keep merged preview checks successful

### DIFF
--- a/apps/deployments-service/internal/service/pull_request_deployments.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments.go
@@ -729,7 +729,7 @@ func (s *Service) RestorePullRequestDeployment(ctx context.Context, req *connect
 	expiresAt := now.Add(time.Duration(config.RestoredPreviewTTLHours) * time.Hour)
 	result := database.DB.WithContext(ctx).Model(&database.PullRequestDeployment{}).
 		Where("id = ? AND merged = ? AND closed_at IS NOT NULL AND active_head_sha IS NULL", record.ID, true).
-		Updates(map[string]interface{}{"preview_deployment_id": nil, "github_deployment_id": nil, "github_deployment_sha": nil, "github_check_run_id": nil, "github_check_run_sha": nil, "status": int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_QUEUED), "error": nil, "closed_at": nil, "closed_from_status": nil, "restored_at": now, "expires_at": expiresAt, "updated_at": now})
+		Updates(map[string]interface{}{"preview_deployment_id": nil, "github_deployment_id": nil, "github_deployment_sha": nil, "github_check_run_id": nil, "github_check_run_sha": nil, "status": int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_QUEUED), "error": nil, "closed_at": nil, "closed_from_status": nil, "closed_from_error": nil, "restored_at": now, "expires_at": expiresAt, "updated_at": now})
 	if result.Error != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to restore pull request environment: %w", result.Error))
 	}
@@ -1658,6 +1658,7 @@ func closePullRequestDeploymentRecord(record *database.PullRequestDeployment, re
 	if record.ClosedFromStatus == nil && record.Status != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED) {
 		closedFromStatus := record.Status
 		record.ClosedFromStatus = &closedFromStatus
+		record.ClosedFromError = record.Error
 	}
 	record.Status, record.ActiveHeadSHA, record.ClosedAt, record.UpdatedAt = int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED), nil, &now, now
 	if reason != "" {
@@ -2223,7 +2224,7 @@ func (s *Service) processPullRequestWebhookLocked(ctx context.Context, config da
 		record.GitHubCheckRunID, record.GitHubCheckRunSHA = nil, nil
 	}
 	record.HeadSHA, record.IgnoredHeadSHA, record.HeadRef, record.BaseRef, record.FromFork, record.Draft = payload.PullRequest.Head.SHA, nil, headRef, baseRef, fromFork, payload.PullRequest.Draft
-	record.ClosedAt, record.ClosedFromStatus, record.UpdatedAt = nil, nil, now
+	record.ClosedAt, record.ClosedFromStatus, record.ClosedFromError, record.UpdatedAt = nil, nil, nil, now
 	if reconcilingRestoredPreview {
 		record.Merged = true
 		record.RestoredAt = restoredAt
@@ -2301,6 +2302,7 @@ func (s *Service) processPullRequestWebhookLocked(ctx context.Context, config da
 			"expires_at":             record.ExpiresAt,
 			"closed_at":              nil,
 			"closed_from_status":     nil,
+			"closed_from_error":      nil,
 			"restored_at":            record.RestoredAt,
 			"updated_at":             record.UpdatedAt,
 		}
@@ -2610,7 +2612,11 @@ func githubPRCheckRun(record *database.PullRequestDeployment, source *database.D
 		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED:
 			status, conclusion, title, summary = "completed", "failure", "Preview failed", "The preview did not deploy successfully. Open Obiente Cloud for build output."
 		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED:
-			status, conclusion, title, summary = "completed", "skipped", "Preview not deployed", stringValue(record.Error)
+			summary = strings.TrimSpace(stringValue(record.ClosedFromError))
+			if summary == "" {
+				summary = "The preview was not deployed."
+			}
+			status, conclusion, title = "completed", "skipped", "Preview not deployed"
 		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_WAITING_APPROVAL:
 			status, conclusion, title, summary = "completed", "action_required", "Maintainer approval required", "Approve the current revision in Obiente before it can run."
 		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_REJECTED:

--- a/apps/deployments-service/internal/service/pull_request_deployments.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments.go
@@ -729,7 +729,7 @@ func (s *Service) RestorePullRequestDeployment(ctx context.Context, req *connect
 	expiresAt := now.Add(time.Duration(config.RestoredPreviewTTLHours) * time.Hour)
 	result := database.DB.WithContext(ctx).Model(&database.PullRequestDeployment{}).
 		Where("id = ? AND merged = ? AND closed_at IS NOT NULL AND active_head_sha IS NULL", record.ID, true).
-		Updates(map[string]interface{}{"preview_deployment_id": nil, "github_deployment_id": nil, "github_deployment_sha": nil, "github_check_run_id": nil, "github_check_run_sha": nil, "status": int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_QUEUED), "error": nil, "closed_at": nil, "restored_at": now, "expires_at": expiresAt, "updated_at": now})
+		Updates(map[string]interface{}{"preview_deployment_id": nil, "github_deployment_id": nil, "github_deployment_sha": nil, "github_check_run_id": nil, "github_check_run_sha": nil, "status": int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_QUEUED), "error": nil, "closed_at": nil, "closed_from_status": nil, "restored_at": now, "expires_at": expiresAt, "updated_at": now})
 	if result.Error != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to restore pull request environment: %w", result.Error))
 	}
@@ -1646,15 +1646,23 @@ func (s *Service) cleanupPullRequestDeployment(ctx context.Context, record *data
 		}
 	}
 	now := time.Now()
-	record.Status, record.ActiveHeadSHA, record.ClosedAt, record.UpdatedAt = int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED), nil, &now, now
-	if reason != "" {
-		record.Error = &reason
-	}
+	closePullRequestDeploymentRecord(record, reason, now)
 	if err := database.DB.WithContext(ctx).Save(record).Error; err != nil {
 		return err
 	}
 	go s.reportPullRequestDeployment(record.ID)
 	return nil
+}
+
+func closePullRequestDeploymentRecord(record *database.PullRequestDeployment, reason string, now time.Time) {
+	if record.ClosedFromStatus == nil && record.Status != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED) {
+		closedFromStatus := record.Status
+		record.ClosedFromStatus = &closedFromStatus
+	}
+	record.Status, record.ActiveHeadSHA, record.ClosedAt, record.UpdatedAt = int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED), nil, &now, now
+	if reason != "" {
+		record.Error = &reason
+	}
 }
 
 func (s *Service) cleanupPullRequestDeploymentsForSource(ctx context.Context, sourceDeploymentID string) error {
@@ -2215,7 +2223,7 @@ func (s *Service) processPullRequestWebhookLocked(ctx context.Context, config da
 		record.GitHubCheckRunID, record.GitHubCheckRunSHA = nil, nil
 	}
 	record.HeadSHA, record.IgnoredHeadSHA, record.HeadRef, record.BaseRef, record.FromFork, record.Draft = payload.PullRequest.Head.SHA, nil, headRef, baseRef, fromFork, payload.PullRequest.Draft
-	record.ClosedAt, record.UpdatedAt = nil, now
+	record.ClosedAt, record.ClosedFromStatus, record.UpdatedAt = nil, nil, now
 	if reconcilingRestoredPreview {
 		record.Merged = true
 		record.RestoredAt = restoredAt
@@ -2292,6 +2300,7 @@ func (s *Service) processPullRequestWebhookLocked(ctx context.Context, config da
 			"error":                  record.Error,
 			"expires_at":             record.ExpiresAt,
 			"closed_at":              nil,
+			"closed_from_status":     nil,
 			"restored_at":            record.RestoredAt,
 			"updated_at":             record.UpdatedAt,
 		}
@@ -2588,9 +2597,26 @@ func githubPRCheckRun(record *database.PullRequestDeployment, source *database.D
 	case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_REJECTED:
 		status, conclusion, title, summary = "completed", "failure", "Preview rejected", "A maintainer rejected this preview."
 	case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED:
-		if record.Merged {
+		closedFromStatus := deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_STATUS_UNSPECIFIED
+		if record.ClosedFromStatus != nil {
+			closedFromStatus = deploymentsv1.PullRequestDeploymentStatus(*record.ClosedFromStatus)
+		}
+		switch closedFromStatus {
+		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING:
+			if !record.Merged {
+				break
+			}
 			status, conclusion, title, summary = "completed", "success", "Preview cleanup complete", "The pull request was merged and its preview environment has been removed."
-		} else {
+		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED:
+			status, conclusion, title, summary = "completed", "failure", "Preview failed", "The preview did not deploy successfully. Open Obiente Cloud for build output."
+		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED:
+			status, conclusion, title, summary = "completed", "skipped", "Preview not deployed", stringValue(record.Error)
+		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_WAITING_APPROVAL:
+			status, conclusion, title, summary = "completed", "action_required", "Maintainer approval required", "Approve the current revision in Obiente before it can run."
+		case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_REJECTED:
+			status, conclusion, title, summary = "completed", "failure", "Preview rejected", "A maintainer rejected this preview."
+		}
+		if conclusion == "" {
 			status, conclusion, title, summary = "completed", "cancelled", "Preview removed", "The pull request environment has been removed."
 		}
 	}

--- a/apps/deployments-service/internal/service/pull_request_deployments.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments.go
@@ -2588,7 +2588,11 @@ func githubPRCheckRun(record *database.PullRequestDeployment, source *database.D
 	case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_REJECTED:
 		status, conclusion, title, summary = "completed", "failure", "Preview rejected", "A maintainer rejected this preview."
 	case deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED:
-		status, conclusion, title, summary = "completed", "cancelled", "Preview removed", "The pull request environment has been removed."
+		if record.Merged {
+			status, conclusion, title, summary = "completed", "success", "Preview cleanup complete", "The pull request was merged and its preview environment has been removed."
+		} else {
+			status, conclusion, title, summary = "completed", "cancelled", "Preview removed", "The pull request environment has been removed."
+		}
 	}
 	return githubclient.CheckRunUpdate{Name: "Obiente Preview · " + sourceName(source, record.SourceDeploymentID), HeadSHA: record.HeadSHA, DetailsURL: detailsURL, ExternalID: record.ID, Status: status, Conclusion: conclusion, Title: title, Summary: summary}
 }

--- a/apps/deployments-service/internal/service/pull_request_deployments_test.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments_test.go
@@ -715,6 +715,30 @@ func TestPullRequestReportRetryBackoffIsBounded(t *testing.T) {
 	}
 }
 
+func TestMergedPullRequestCleanupCompletesGitHubCheckSuccessfully(t *testing.T) {
+	record := &database.PullRequestDeployment{
+		Merged: true,
+		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+	}
+	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
+	if check.Status != "completed" || check.Conclusion != "success" {
+		t.Fatalf("merged cleanup check = %s/%s, want completed/success", check.Status, check.Conclusion)
+	}
+	if check.Title != "Preview cleanup complete" || !strings.Contains(check.Summary, "merged") {
+		t.Fatalf("merged cleanup output = %q / %q", check.Title, check.Summary)
+	}
+}
+
+func TestUnmergedPullRequestCleanupRemainsCancelled(t *testing.T) {
+	record := &database.PullRequestDeployment{
+		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+	}
+	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
+	if check.Status != "completed" || check.Conclusion != "cancelled" {
+		t.Fatalf("unmerged cleanup check = %s/%s, want completed/cancelled", check.Status, check.Conclusion)
+	}
+}
+
 func TestPullRequestBooleanSettingsDoNotHaveORMDefaults(t *testing.T) {
 	typeOfConfig := reflect.TypeOf(database.PullRequestDeploymentConfig{})
 	for _, name := range []string{"RedeployOnPush", "CleanupOnClose", "CommentEnabled", "DeploymentStatusEnabled", "CheckRunEnabled"} {

--- a/apps/deployments-service/internal/service/pull_request_deployments_test.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments_test.go
@@ -716,9 +716,11 @@ func TestPullRequestReportRetryBackoffIsBounded(t *testing.T) {
 }
 
 func TestMergedPullRequestCleanupCompletesGitHubCheckSuccessfully(t *testing.T) {
+	running := int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING)
 	record := &database.PullRequestDeployment{
-		Merged: true,
-		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+		Merged:           true,
+		Status:           int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+		ClosedFromStatus: &running,
 	}
 	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
 	if check.Status != "completed" || check.Conclusion != "success" {
@@ -729,13 +731,71 @@ func TestMergedPullRequestCleanupCompletesGitHubCheckSuccessfully(t *testing.T) 
 	}
 }
 
+func TestMergedPullRequestCleanupPreservesUnsuccessfulGitHubChecks(t *testing.T) {
+	tests := []struct {
+		name       string
+		prior      deploymentsv1.PullRequestDeploymentStatus
+		conclusion string
+		title      string
+	}{
+		{name: "failed", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED, conclusion: "failure", title: "Preview failed"},
+		{name: "rejected", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_REJECTED, conclusion: "failure", title: "Preview rejected"},
+		{name: "waiting approval", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_WAITING_APPROVAL, conclusion: "action_required", title: "Maintainer approval required"},
+		{name: "skipped", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED, conclusion: "skipped", title: "Preview not deployed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prior := int32(test.prior)
+			record := &database.PullRequestDeployment{
+				Merged:           true,
+				Status:           int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+				ClosedFromStatus: &prior,
+			}
+			check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
+			if check.Status != "completed" || check.Conclusion != test.conclusion || check.Title != test.title {
+				t.Fatalf("merged cleanup check = %s/%s/%q, want completed/%s/%q", check.Status, check.Conclusion, check.Title, test.conclusion, test.title)
+			}
+		})
+	}
+}
+
+func TestPullRequestCleanupRecordsAndPreservesPreviousStatus(t *testing.T) {
+	record := &database.PullRequestDeployment{Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED)}
+	closedAt := time.Now()
+	closePullRequestDeploymentRecord(record, "Pull request closed.", closedAt)
+	if record.ClosedFromStatus == nil || *record.ClosedFromStatus != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED) {
+		t.Fatalf("closed from status = %v, want failed", record.ClosedFromStatus)
+	}
+	if record.Status != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED) || record.ClosedAt == nil || !record.ClosedAt.Equal(closedAt) {
+		t.Fatalf("closed record = status %d at %v", record.Status, record.ClosedAt)
+	}
+
+	closePullRequestDeploymentRecord(record, "Cleanup retried.", closedAt.Add(time.Minute))
+	if *record.ClosedFromStatus != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED) {
+		t.Fatalf("cleanup retry replaced prior status with %d", *record.ClosedFromStatus)
+	}
+}
+
 func TestUnmergedPullRequestCleanupRemainsCancelled(t *testing.T) {
+	running := int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_RUNNING)
 	record := &database.PullRequestDeployment{
-		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+		Status:           int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+		ClosedFromStatus: &running,
 	}
 	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
 	if check.Status != "completed" || check.Conclusion != "cancelled" {
 		t.Fatalf("unmerged cleanup check = %s/%s, want completed/cancelled", check.Status, check.Conclusion)
+	}
+}
+
+func TestMergedPullRequestCleanupWithoutRecordedPriorStatusRemainsCancelled(t *testing.T) {
+	record := &database.PullRequestDeployment{
+		Merged: true,
+		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+	}
+	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
+	if check.Status != "completed" || check.Conclusion != "cancelled" {
+		t.Fatalf("legacy merged cleanup check = %s/%s, want completed/cancelled", check.Status, check.Conclusion)
 	}
 }
 

--- a/apps/deployments-service/internal/service/pull_request_deployments_test.go
+++ b/apps/deployments-service/internal/service/pull_request_deployments_test.go
@@ -737,42 +737,58 @@ func TestMergedPullRequestCleanupPreservesUnsuccessfulGitHubChecks(t *testing.T)
 		prior      deploymentsv1.PullRequestDeploymentStatus
 		conclusion string
 		title      string
+		summary    string
 	}{
 		{name: "failed", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED, conclusion: "failure", title: "Preview failed"},
 		{name: "rejected", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_REJECTED, conclusion: "failure", title: "Preview rejected"},
 		{name: "waiting approval", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_WAITING_APPROVAL, conclusion: "action_required", title: "Maintainer approval required"},
-		{name: "skipped", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED, conclusion: "skipped", title: "Preview not deployed"},
+		{name: "skipped", prior: deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED, conclusion: "skipped", title: "Preview not deployed", summary: "No changed files match this preview scope."},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			prior := int32(test.prior)
+			priorError := test.summary
 			record := &database.PullRequestDeployment{
 				Merged:           true,
 				Status:           int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
 				ClosedFromStatus: &prior,
+				ClosedFromError:  &priorError,
 			}
 			check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
 			if check.Status != "completed" || check.Conclusion != test.conclusion || check.Title != test.title {
 				t.Fatalf("merged cleanup check = %s/%s/%q, want completed/%s/%q", check.Status, check.Conclusion, check.Title, test.conclusion, test.title)
+			}
+			if test.summary != "" && check.Summary != test.summary {
+				t.Fatalf("merged cleanup summary = %q, want %q", check.Summary, test.summary)
 			}
 		})
 	}
 }
 
 func TestPullRequestCleanupRecordsAndPreservesPreviousStatus(t *testing.T) {
-	record := &database.PullRequestDeployment{Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED)}
+	priorError := "No changed files match this preview scope."
+	record := &database.PullRequestDeployment{
+		Status: int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED),
+		Error:  &priorError,
+	}
 	closedAt := time.Now()
 	closePullRequestDeploymentRecord(record, "Pull request closed.", closedAt)
-	if record.ClosedFromStatus == nil || *record.ClosedFromStatus != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED) {
-		t.Fatalf("closed from status = %v, want failed", record.ClosedFromStatus)
+	if record.ClosedFromStatus == nil || *record.ClosedFromStatus != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED) {
+		t.Fatalf("closed from status = %v, want skipped", record.ClosedFromStatus)
+	}
+	if record.ClosedFromError == nil || *record.ClosedFromError != priorError {
+		t.Fatalf("closed from error = %v, want %q", record.ClosedFromError, priorError)
 	}
 	if record.Status != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED) || record.ClosedAt == nil || !record.ClosedAt.Equal(closedAt) {
 		t.Fatalf("closed record = status %d at %v", record.Status, record.ClosedAt)
 	}
 
 	closePullRequestDeploymentRecord(record, "Cleanup retried.", closedAt.Add(time.Minute))
-	if *record.ClosedFromStatus != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_FAILED) {
+	if *record.ClosedFromStatus != int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED) {
 		t.Fatalf("cleanup retry replaced prior status with %d", *record.ClosedFromStatus)
+	}
+	if record.ClosedFromError == nil || *record.ClosedFromError != priorError {
+		t.Fatalf("cleanup retry replaced prior error with %v", record.ClosedFromError)
 	}
 }
 
@@ -796,6 +812,19 @@ func TestMergedPullRequestCleanupWithoutRecordedPriorStatusRemainsCancelled(t *t
 	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
 	if check.Status != "completed" || check.Conclusion != "cancelled" {
 		t.Fatalf("legacy merged cleanup check = %s/%s, want completed/cancelled", check.Status, check.Conclusion)
+	}
+}
+
+func TestSkippedCleanupWithoutRecordedReasonUsesGenericSummary(t *testing.T) {
+	skipped := int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_SKIPPED)
+	record := &database.PullRequestDeployment{
+		Merged:           true,
+		Status:           int32(deploymentsv1.PullRequestDeploymentStatus_PULL_REQUEST_DEPLOYMENT_CLOSED),
+		ClosedFromStatus: &skipped,
+	}
+	check := githubPRCheckRun(record, &database.Deployment{Name: "NC Native"}, "")
+	if check.Conclusion != "skipped" || check.Summary != "The preview was not deployed." {
+		t.Fatalf("legacy skipped cleanup check = %s/%q", check.Conclusion, check.Summary)
 	}
 }
 

--- a/apps/shared/pkg/database/db.go
+++ b/apps/shared/pkg/database/db.go
@@ -692,6 +692,7 @@ func ensurePullRequestPreviewCompatibilityColumns(db *gorm.DB) error {
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS report_attempts INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS next_report_at TIMESTAMPTZ`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS restored_at TIMESTAMPTZ`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS closed_from_status INTEGER`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS isolation_version INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE IF EXISTS pull_request_deployment_configs ADD COLUMN IF NOT EXISTS reconciliation_pending BOOLEAN NOT NULL DEFAULT FALSE`,
 		`ALTER TABLE IF EXISTS pull_request_deployment_configs ADD COLUMN IF NOT EXISTS reconciliation_generation BIGINT NOT NULL DEFAULT 0`,

--- a/apps/shared/pkg/database/db.go
+++ b/apps/shared/pkg/database/db.go
@@ -693,6 +693,7 @@ func ensurePullRequestPreviewCompatibilityColumns(db *gorm.DB) error {
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS next_report_at TIMESTAMPTZ`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS restored_at TIMESTAMPTZ`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS closed_from_status INTEGER`,
+		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS closed_from_error TEXT`,
 		`ALTER TABLE IF EXISTS pull_request_deployments ADD COLUMN IF NOT EXISTS isolation_version INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE IF EXISTS pull_request_deployment_configs ADD COLUMN IF NOT EXISTS reconciliation_pending BOOLEAN NOT NULL DEFAULT FALSE`,
 		`ALTER TABLE IF EXISTS pull_request_deployment_configs ADD COLUMN IF NOT EXISTS reconciliation_generation BIGINT NOT NULL DEFAULT 0`,

--- a/apps/shared/pkg/database/models.go
+++ b/apps/shared/pkg/database/models.go
@@ -138,6 +138,7 @@ type PullRequestDeployment struct {
 	ExpiresAt            time.Time  `gorm:"index;not null" json:"expires_at"`
 	ClosedAt             *time.Time `gorm:"index" json:"closed_at"`
 	ClosedFromStatus     *int32     `json:"closed_from_status"`
+	ClosedFromError      *string    `gorm:"type:text" json:"closed_from_error"`
 	RestoredAt           *time.Time `gorm:"index" json:"restored_at"`
 	CreatedAt            time.Time  `json:"created_at"`
 	UpdatedAt            time.Time  `json:"updated_at"`

--- a/apps/shared/pkg/database/models.go
+++ b/apps/shared/pkg/database/models.go
@@ -137,6 +137,7 @@ type PullRequestDeployment struct {
 	ApprovedAt           *time.Time `json:"approved_at"`
 	ExpiresAt            time.Time  `gorm:"index;not null" json:"expires_at"`
 	ClosedAt             *time.Time `gorm:"index" json:"closed_at"`
+	ClosedFromStatus     *int32     `json:"closed_from_status"`
 	RestoredAt           *time.Time `gorm:"index" json:"restored_at"`
 	CreatedAt            time.Time  `json:"created_at"`
 	UpdatedAt            time.Time  `json:"updated_at"`


### PR DESCRIPTION
## Summary

- conclude merged pull request preview cleanup checks successfully
- keep unmerged preview removal checks cancelled
- cover both lifecycle outcomes with focused regression tests

## Root cause

The GitHub check mapper treated every closed preview environment as `cancelled`. After a pull request merged and its successfully deployed preview was cleaned up, that final update replaced the successful preview result with a cancelled conclusion and gave the merged pull request a red X.

Merged cleanup now reports `completed/success` as `Preview cleanup complete`. Unmerged removals retain the existing cancelled result, while build failures and rejected previews keep their existing failure conclusions.

## Validation

- `go test ./internal/service -run 'Test(MergedPullRequestCleanupCompletesGitHubCheckSuccessfully|UnmergedPullRequestCleanupRemainsCancelled)$' -count=1`
- `go test ./internal/github -count=1`
- `git diff --check`
