### PR TITLE
fix(dns): route resources to their owning nodes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,12 +117,14 @@ INTERNAL_SERVICE_SECRET=your_internal_service_secret_here_generate_with_openssl_
 # DNS Configuration
 # =============================================================================
 # Node IPs per region (REQUIRED for DNS resolution)
-# Maps regions to node IP addresses for DNS resolution of deployments and game servers
+# Maps regions or exact Swarm node IDs/hostnames to public node IP addresses
 # Format: "region1:ip1,ip2;region2:ip3,ip4" or simple "ip1,ip2" (defaults to "default" region)
+# Database owners in a region with multiple nodes require a node-specific entry containing one IP.
 # Examples:
 #   Simple: NODE_IPS="1.2.3.4" or NODE_IPS="1.2.3.4,1.2.3.5"
 #   Single region: NODE_IPS="us-east-1:1.2.3.4,1.2.3.5"
 #   Multiple regions: NODE_IPS="us-east-1:1.2.3.4,1.2.3.5;eu-west-1:5.6.7.8,5.6.7.9"
+#   Node-specific: NODE_IPS="owner-node:192.0.2.10;us-east-1:192.0.2.10,192.0.2.11"
 #   Explicit default: NODE_IPS="default:1.2.3.4"
 NODE_IPS=
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker swarm init
 # Or build manually, then deploy:
 export DOCKER_BUILDKIT=1
 docker build -f apps/api/Dockerfile -t obiente/cloud-api:latest .
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 
 # For multi-node deployments, push images to a registry or use docker save/load
 # docker tag obiente/cloud-api:latest your-registry/obiente/cloud-api:latest

--- a/apps/databases-service/internal/provisioner/docker.go
+++ b/apps/databases-service/internal/provisioner/docker.go
@@ -31,10 +31,13 @@ type DatabaseConfig struct {
 
 // ProvisioningResult contains result information
 type ProvisioningResult struct {
-	ContainerID string // Docker container ID
-	Host        string // Internal hostname
-	Port        int    // Exposed port
-	Status      string // Current status
+	ContainerID  string // Docker container ID
+	Host         string // Internal hostname
+	Port         int    // Exposed port
+	Status       string // Current status
+	NodeID       string // Docker node ID that owns the container
+	NodeHostname string // Docker node hostname
+	NodeIP       string // Public/reachable address reported by Docker
 }
 
 // DatabaseType enum
@@ -81,6 +84,11 @@ func NewDockerProvisioner() (*DockerProvisioner, error) {
 // ProvisionDatabase creates and starts a new database container
 func (p *DockerProvisioner) ProvisionDatabase(ctx context.Context, cfg *DatabaseConfig) (*ProvisioningResult, error) {
 	logger.Info("Provisioning database: %s (type: %s)", cfg.DatabaseID, cfg.Type.String())
+
+	node, err := p.client.CurrentNodeIdentity(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine database host node: %w", err)
+	}
 
 	// Get image and config for database type
 	image := p.getImageForType(cfg.Type, cfg.Version)
@@ -169,10 +177,13 @@ func (p *DockerProvisioner) ProvisionDatabase(ctx context.Context, cfg *Database
 	logger.Info("Database container provisioned: %s (ID: %s)", containerName, containerID)
 
 	return &ProvisioningResult{
-		ContainerID: containerID,
-		Host:        hostname,
-		Port:        standardPort,
-		Status:      "running",
+		ContainerID:  containerID,
+		Host:         hostname,
+		Port:         standardPort,
+		Status:       "running",
+		NodeID:       node.ID,
+		NodeHostname: node.Hostname,
+		NodeIP:       node.IP,
 	}, nil
 }
 

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -205,6 +205,11 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	newRoutes := make(map[string]*Route, len(instances))
 	newRoutesByID := make(map[string]*Route, len(instances))
 	newUsedRedisPorts := make(map[int]string)
+	var localNode docker.NodeIdentity
+	var localNodeErr error
+	if r.dockerClient != nil {
+		localNode, localNodeErr = r.dockerClient.CurrentNodeIdentity(ctx)
+	}
 
 	for _, inst := range instances {
 		dbType := databaseTypeIntToString(inst.Type)
@@ -231,6 +236,12 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 
 		if inst.InstanceID != nil {
 			route.ContainerID = *inst.InstanceID
+		}
+		locationNeedsReconciliation := inst.NodeID == nil || *inst.NodeID != localNode.ID
+		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && locationNeedsReconciliation {
+			if _, err := r.dockerClient.ContainerInspect(ctx, route.ContainerID); err == nil {
+				r.recordDatabaseLocation(ctx, &inst, localNode)
+			}
 		}
 
 		// Load connection credentials
@@ -297,6 +308,34 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 
 	logger.Info("Loaded %d routes from database", len(instances))
 	return nil
+}
+
+func (r *RouteRegistry) recordDatabaseLocation(ctx context.Context, instance *database.DatabaseInstance, node docker.NodeIdentity) {
+	if instance == nil || instance.InstanceID == nil || node.ID == "" {
+		return
+	}
+
+	containerID := *instance.InstanceID
+	if err := database.DB.WithContext(ctx).Model(&database.DatabaseInstance{}).
+		Where("id = ?", instance.ID).
+		Update("node_id", node.ID).Error; err != nil {
+		logger.Warn("Failed to record host node for database %s: %v", instance.ID, err)
+		return
+	}
+	instance.NodeID = &node.ID
+
+	if err := database.UpsertDatabaseLocation(&database.DatabaseLocation{
+		ID:           database.DatabaseLocationID(instance.ID, containerID),
+		DatabaseID:   instance.ID,
+		NodeID:       node.ID,
+		NodeHostname: node.Hostname,
+		NodeIP:       node.IP,
+		ContainerID:  containerID,
+		Status:       "running",
+		Port:         int32(standardPort(databaseTypeIntToString(instance.Type))),
+	}); err != nil {
+		logger.Warn("Failed to reconcile location for database %s: %v", instance.ID, err)
+	}
 }
 
 // StartIPRefresh starts a background goroutine that refreshes container IPs

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -286,12 +286,16 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 			route.ContainerID = *inst.InstanceID
 		}
 		location := knownLocations[route.ContainerID]
+		containerRunning, containerIsLocal := localContainerStates[route.ContainerID]
+		containerOwnedLocally := databaseContainerOwnedLocally(&inst, location, localNode.ID, containerIsLocal)
+		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && !containerOwnedLocally {
+			// Global proxy tasks only publish routes for containers owned by their
+			// local Docker daemon. Owner-specific DNS sends clients to that task.
+			continue
+		}
 		locationReconciled := false
-		containerIsLocal := false
 		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil {
-			containerRunning := false
-			containerRunning, containerIsLocal = localContainerStates[route.ContainerID]
-			if containerIsLocal && inst.Status == 3 && !containerRunning {
+			if containerOwnedLocally && inst.Status == 3 && !containerRunning {
 				if err := reconcileStoppedDatabase(ctx, &inst); err != nil {
 					logger.Warn("Failed to reconcile externally stopped database %s: %v", inst.ID, err)
 				} else {
@@ -374,6 +378,21 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 
 	logger.Info("Loaded %d routes from database", len(instances))
 	return nil
+}
+
+func databaseContainerOwnedLocally(
+	instance *database.DatabaseInstance,
+	location databaseLocationSnapshot,
+	localNodeID string,
+	containerListedLocally bool,
+) bool {
+	if containerListedLocally || localNodeID == "" {
+		return containerListedLocally
+	}
+	if strings.TrimSpace(location.NodeID) == strings.TrimSpace(localNodeID) {
+		return true
+	}
+	return instance != nil && instance.NodeID != nil && strings.TrimSpace(*instance.NodeID) == strings.TrimSpace(localNodeID)
 }
 
 func databaseUptimeNeedsRepair(instanceStatus int32, containerIsLocal, locationReconciled, intervalOpen bool) bool {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +29,13 @@ type Route struct {
 	DBStatus         int32     // Database status code (5=STOPPED, 12=SLEEPING)
 	AutoSleepSeconds int32     // Auto-sleep after inactivity (0 = disabled)
 	LastConnectionAt time.Time // Last time a client connected
+}
+
+type databaseLocationSnapshot struct {
+	NodeID       string
+	NodeIP       string
+	NodeHostname string
+	Status       string
 }
 
 // WakeFunc starts a sleeping database container and returns the new container IP
@@ -210,7 +218,7 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	if r.dockerClient != nil {
 		localNode, localNodeErr = r.dockerClient.CurrentNodeIdentity(ctx)
 	}
-	knownLocationNodes := make(map[string]string)
+	knownLocations := make(map[string]databaseLocationSnapshot)
 	if localNodeErr == nil {
 		containerIDs := make([]string, 0, len(instances))
 		for _, instance := range instances {
@@ -224,7 +232,12 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 				localNodeErr = fmt.Errorf("failed to load database locations: %w", err)
 			} else {
 				for _, location := range locations {
-					knownLocationNodes[location.ContainerID] = location.NodeID
+					knownLocations[location.ContainerID] = databaseLocationSnapshot{
+						NodeID:       location.NodeID,
+						NodeIP:       location.NodeIP,
+						NodeHostname: location.NodeHostname,
+						Status:       location.Status,
+					}
 				}
 			}
 		}
@@ -256,7 +269,7 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 		if inst.InstanceID != nil {
 			route.ContainerID = *inst.InstanceID
 		}
-		locationNeedsReconciliation := inst.NodeID == nil || *inst.NodeID != localNode.ID || knownLocationNodes[route.ContainerID] != localNode.ID
+		locationNeedsReconciliation := databaseLocationNeedsReconciliation(&inst, knownLocations[route.ContainerID], localNode)
 		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && locationNeedsReconciliation {
 			if _, err := r.dockerClient.ContainerInspect(ctx, route.ContainerID); err == nil {
 				r.recordDatabaseLocation(ctx, &inst, localNode)
@@ -332,6 +345,19 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 
 	logger.Info("Loaded %d routes from database", len(instances))
 	return nil
+}
+
+func databaseLocationNeedsReconciliation(instance *database.DatabaseInstance, location databaseLocationSnapshot, localNode docker.NodeIdentity) bool {
+	if instance == nil {
+		return false
+	}
+	if instance.NodeID == nil || strings.TrimSpace(*instance.NodeID) != strings.TrimSpace(localNode.ID) {
+		return true
+	}
+	return strings.TrimSpace(location.NodeID) != strings.TrimSpace(localNode.ID) ||
+		strings.TrimSpace(location.NodeIP) != strings.TrimSpace(localNode.IP) ||
+		strings.TrimSpace(location.NodeHostname) != strings.TrimSpace(localNode.Hostname) ||
+		location.Status != databaseLocationStatus(instance.Status)
 }
 
 func (r *RouteRegistry) recordDatabaseLocation(ctx context.Context, instance *database.DatabaseInstance, node docker.NodeIdentity) {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -315,6 +315,9 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 			}
 		}
 	}
+	if localRoutesOnly && localNodeErr != nil {
+		return fmt.Errorf("cannot refresh local database routes: %w", localNodeErr)
+	}
 
 	for _, inst := range instances {
 		dbType := databaseTypeIntToString(inst.Type)
@@ -497,11 +500,8 @@ func reconcileStoppedDatabase(ctx context.Context, instance *database.DatabaseIn
 	if instance == nil {
 		return nil
 	}
-	if err := database.UpdateDatabaseInstanceStatus(ctx, instance.ID, 5); err != nil {
-		return fmt.Errorf("update database instance status: %w", err)
-	}
-	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "stopped"); err != nil {
-		return fmt.Errorf("update database location status: %w", err)
+	if err := database.UpdateDatabaseRuntimeStatus(ctx, instance.ID, 5, "stopped"); err != nil {
+		return fmt.Errorf("update stopped database runtime status: %w", err)
 	}
 	return nil
 }
@@ -510,11 +510,8 @@ func reconcileRunningDatabase(ctx context.Context, instance *database.DatabaseIn
 	if instance == nil {
 		return nil
 	}
-	if err := database.UpdateDatabaseInstanceStatus(ctx, instance.ID, 3); err != nil {
-		return fmt.Errorf("update database instance status: %w", err)
-	}
-	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "running"); err != nil {
-		return fmt.Errorf("update database location status: %w", err)
+	if err := database.UpdateDatabaseRuntimeStatus(ctx, instance.ID, 3, "running"); err != nil {
+		return fmt.Errorf("update running database runtime status: %w", err)
 	}
 	return nil
 }

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -262,6 +262,11 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 				r.recordDatabaseLocation(ctx, &inst, localNode)
 			}
 		}
+		if inst.Status == 3 {
+			if err := database.EnsureDatabaseUptimeInterval(ctx, inst.ID); err != nil {
+				logger.Warn("Failed to reconcile uptime interval for database %s: %v", inst.ID, err)
+			}
+		}
 
 		// Load connection credentials
 		if conn, ok := connMap[inst.ID]; ok {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -210,6 +210,25 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	if r.dockerClient != nil {
 		localNode, localNodeErr = r.dockerClient.CurrentNodeIdentity(ctx)
 	}
+	knownLocationNodes := make(map[string]string)
+	if localNodeErr == nil {
+		containerIDs := make([]string, 0, len(instances))
+		for _, instance := range instances {
+			if instance.InstanceID != nil && *instance.InstanceID != "" {
+				containerIDs = append(containerIDs, *instance.InstanceID)
+			}
+		}
+		if len(containerIDs) > 0 {
+			var locations []database.DatabaseLocation
+			if err := database.DB.WithContext(ctx).Where("container_id IN ?", containerIDs).Find(&locations).Error; err != nil {
+				localNodeErr = fmt.Errorf("failed to load database locations: %w", err)
+			} else {
+				for _, location := range locations {
+					knownLocationNodes[location.ContainerID] = location.NodeID
+				}
+			}
+		}
+	}
 
 	for _, inst := range instances {
 		dbType := databaseTypeIntToString(inst.Type)
@@ -237,7 +256,7 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 		if inst.InstanceID != nil {
 			route.ContainerID = *inst.InstanceID
 		}
-		locationNeedsReconciliation := inst.NodeID == nil || *inst.NodeID != localNode.ID
+		locationNeedsReconciliation := inst.NodeID == nil || *inst.NodeID != localNode.ID || knownLocationNodes[route.ContainerID] != localNode.ID
 		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && locationNeedsReconciliation {
 			if _, err := r.dockerClient.ContainerInspect(ctx, route.ContainerID); err == nil {
 				r.recordDatabaseLocation(ctx, &inst, localNode)
@@ -331,10 +350,41 @@ func (r *RouteRegistry) recordDatabaseLocation(ctx context.Context, instance *da
 		NodeHostname: node.Hostname,
 		NodeIP:       node.IP,
 		ContainerID:  containerID,
-		Status:       "running",
+		Status:       databaseLocationStatus(instance.Status),
 		Port:         int32(standardPort(databaseTypeIntToString(instance.Type))),
 	}); err != nil {
 		logger.Warn("Failed to reconcile location for database %s: %v", instance.ID, err)
+	}
+}
+
+func databaseLocationStatus(status int32) string {
+	switch status {
+	case 1:
+		return "creating"
+	case 2:
+		return "starting"
+	case 3:
+		return "running"
+	case 4:
+		return "stopping"
+	case 5:
+		return "stopped"
+	case 6:
+		return "backing_up"
+	case 7:
+		return "restoring"
+	case 8:
+		return "failed"
+	case 9:
+		return "deleting"
+	case 10:
+		return "deleted"
+	case 11:
+		return "suspended"
+	case 12:
+		return "sleeping"
+	default:
+		return "created"
 	}
 }
 

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -73,6 +73,31 @@ func (r *RouteRegistry) SetLocalRoutesOnly(localOnly bool) {
 	r.localOnly = localOnly
 }
 
+func (r *RouteRegistry) StartDatabaseSync(ctx context.Context, interval time.Duration) <-chan struct{} {
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				syncCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+				if err := r.LoadFromDatabase(syncCtx); err != nil {
+					logger.Warn("Failed to refresh database routes: %v", err)
+				}
+				cancel()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return done
+}
+
 // NewRouteRegistry creates a new route registry
 func NewRouteRegistry(dockerClient *docker.Client) *RouteRegistry {
 	return &RouteRegistry{
@@ -464,9 +489,7 @@ func reconcileStoppedDatabase(ctx context.Context, instance *database.DatabaseIn
 	if instance == nil {
 		return nil
 	}
-	if err := database.DB.WithContext(ctx).Model(&database.DatabaseInstance{}).
-		Where("id = ?", instance.ID).
-		Update("status", 5).Error; err != nil {
+	if err := database.UpdateDatabaseInstanceStatus(ctx, instance.ID, 5); err != nil {
 		return fmt.Errorf("update database instance status: %w", err)
 	}
 	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "stopped"); err != nil {
@@ -479,9 +502,7 @@ func reconcileRunningDatabase(ctx context.Context, instance *database.DatabaseIn
 	if instance == nil {
 		return nil
 	}
-	if err := database.DB.WithContext(ctx).Model(&database.DatabaseInstance{}).
-		Where("id = ?", instance.ID).
-		Update("status", 3).Error; err != nil {
+	if err := database.UpdateDatabaseInstanceStatus(ctx, instance.ID, 3); err != nil {
 		return fmt.Errorf("update database instance status: %w", err)
 	}
 	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "running"); err != nil {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -215,7 +215,7 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	newUsedRedisPorts := make(map[int]string)
 	var localNode docker.NodeIdentity
 	var localNodeErr error
-	var localContainerStates map[string]bool
+	var localContainerStates map[string]string
 	if r.dockerClient != nil {
 		localNode, localNodeErr = r.dockerClient.CurrentNodeIdentity(ctx)
 		if localNodeErr == nil {
@@ -286,7 +286,7 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 			route.ContainerID = *inst.InstanceID
 		}
 		location := knownLocations[route.ContainerID]
-		containerRunning, containerIsLocal := localContainerStates[route.ContainerID]
+		containerState, containerIsLocal := localContainerStates[route.ContainerID]
 		containerOwnedLocally := databaseContainerOwnedLocally(&inst, location, localNode.ID, containerIsLocal)
 		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && !containerOwnedLocally {
 			// Global proxy tasks only publish routes for containers owned by their
@@ -295,7 +295,7 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 		}
 		locationReconciled := false
 		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil {
-			if containerOwnedLocally && inst.Status == 3 && !containerRunning {
+			if containerOwnedLocally && inst.Status == 3 && databaseContainerTerminallyUnavailable(containerState, containerIsLocal) {
 				if err := reconcileStoppedDatabase(ctx, &inst); err != nil {
 					logger.Warn("Failed to reconcile externally stopped database %s: %v", inst.ID, err)
 				} else {
@@ -392,7 +392,22 @@ func databaseContainerOwnedLocally(
 	if strings.TrimSpace(location.NodeID) == strings.TrimSpace(localNodeID) {
 		return true
 	}
+	if strings.TrimSpace(location.NodeID) != "" {
+		return false
+	}
 	return instance != nil && instance.NodeID != nil && strings.TrimSpace(*instance.NodeID) == strings.TrimSpace(localNodeID)
+}
+
+func databaseContainerTerminallyUnavailable(state string, listedLocally bool) bool {
+	if !listedLocally {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "exited", "dead":
+		return true
+	default:
+		return false
+	}
 }
 
 func databaseUptimeNeedsRepair(instanceStatus int32, containerIsLocal, locationReconciled, intervalOpen bool) bool {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -51,6 +51,7 @@ type RouteRegistry struct {
 	routesByID   map[string]*Route // keyed by database ID
 	dockerClient *docker.Client
 	stopRefresh  chan struct{}
+	localOnly    bool
 
 	// Wake/sleep callbacks (set by service layer)
 	OnWake  WakeFunc
@@ -61,6 +62,15 @@ type RouteRegistry struct {
 	redisPortStart int
 	redisPortEnd   int
 	usedRedisPorts map[int]string // port -> database ID
+}
+
+// SetLocalRoutesOnly limits published proxy routes to containers owned by the
+// local Docker daemon. Control-plane registries retain the global allocation
+// snapshot without opening remote listeners.
+func (r *RouteRegistry) SetLocalRoutesOnly(localOnly bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.localOnly = localOnly
 }
 
 // NewRouteRegistry creates a new route registry
@@ -208,11 +218,25 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	for id, route := range r.routesByID {
 		existingRoutes[id] = route
 	}
+	localRoutesOnly := r.localOnly
 	r.mu.RUnlock()
 
 	newRoutes := make(map[string]*Route, len(instances))
 	newRoutesByID := make(map[string]*Route, len(instances))
 	newUsedRedisPorts := make(map[int]string)
+	for _, inst := range instances {
+		if databaseTypeIntToString(inst.Type) != "redis" {
+			continue
+		}
+		conn := connMap[inst.ID]
+		if conn == nil || !r.validRedisPort(int(conn.ProxyPort)) {
+			continue
+		}
+		port := int(conn.ProxyPort)
+		if _, used := newUsedRedisPorts[port]; !used {
+			newUsedRedisPorts[port] = inst.ID
+		}
+	}
 	var localNode docker.NodeIdentity
 	var localNodeErr error
 	var localContainerStates map[string]string
@@ -285,10 +309,35 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 		if inst.InstanceID != nil {
 			route.ContainerID = *inst.InstanceID
 		}
+		if dbType == "redis" {
+			conn := connMap[inst.ID]
+			port := 0
+			if conn != nil && r.validRedisPort(int(conn.ProxyPort)) && newUsedRedisPorts[int(conn.ProxyPort)] == inst.ID {
+				port = int(conn.ProxyPort)
+			} else {
+				var err error
+				port, err = r.allocateRedisPortLocked(inst.ID, newUsedRedisPorts)
+				if err != nil {
+					logger.Error("Failed to allocate Redis port for %s: %v", inst.ID, err)
+					continue
+				}
+				if conn != nil {
+					if err := database.DB.WithContext(ctx).Model(&database.DatabaseConnection{}).
+						Where("database_id = ?", inst.ID).
+						Update("proxy_port", port).Error; err != nil {
+						logger.Error("Failed to persist Redis proxy port for %s: %v", inst.ID, err)
+						continue
+					}
+					conn.ProxyPort = int32(port)
+				}
+			}
+			route.RedisPort = port
+			newUsedRedisPorts[port] = inst.ID
+		}
 		location := knownLocations[route.ContainerID]
 		containerState, containerIsLocal := localContainerStates[route.ContainerID]
 		containerOwnedLocally := databaseContainerOwnedLocally(&inst, location, localNode.ID, containerIsLocal)
-		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && !containerOwnedLocally {
+		if localRoutesOnly && route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && !containerOwnedLocally {
 			// Global proxy tasks only publish routes for containers owned by their
 			// local Docker daemon. Owner-specific DNS sends clients to that task.
 			continue
@@ -322,22 +371,13 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 
 		// Only resolve IPs for running databases
 		if route.Stopped {
-			if dbType == "redis" {
-				port, err := r.allocateRedisPortLocked(inst.ID, newUsedRedisPorts)
-				if err != nil {
-					logger.Error("Failed to allocate Redis port for %s: %v", inst.ID, err)
-				} else {
-					route.RedisPort = port
-					newUsedRedisPorts[port] = inst.ID
-				}
-			}
 			newRoutes[route.DatabaseID] = route
 			newRoutesByID[route.DatabaseID] = route
 			continue
 		}
 
 		// Ensure container is on the correct network, then resolve IP
-		if route.ContainerID != "" && r.dockerClient != nil {
+		if route.ContainerID != "" && r.dockerClient != nil && containerOwnedLocally {
 			r.reconcileContainerNetwork(ctx, route.ContainerID)
 
 			if ip, err := r.resolveContainerIP(ctx, route.ContainerID); err == nil {
@@ -350,17 +390,6 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 					route.ContainerIP = ip
 				}
 			}
-		}
-
-		// Allocate Redis port if needed
-		if dbType == "redis" {
-			port, err := r.allocateRedisPortLocked(inst.ID, newUsedRedisPorts)
-			if err != nil {
-				logger.Error("Failed to allocate Redis port for %s: %v", inst.ID, err)
-				continue
-			}
-			route.RedisPort = port
-			newUsedRedisPorts[port] = inst.ID
 		}
 
 		newRoutes[route.DatabaseID] = route
@@ -378,6 +407,10 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 
 	logger.Info("Loaded %d routes from database", len(instances))
 	return nil
+}
+
+func (r *RouteRegistry) validRedisPort(port int) bool {
+	return port >= r.redisPortStart && port <= r.redisPortEnd
 }
 
 func databaseContainerOwnedLocally(

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -271,6 +271,14 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 			localContainerStates, localNodeErr = r.dockerClient.ManagedDatabaseContainerStates(ctx)
 		}
 	}
+	if localRoutesOnly {
+		if r.dockerClient == nil {
+			return fmt.Errorf("cannot refresh local database routes: Docker client is unavailable")
+		}
+		if localNodeErr != nil {
+			return fmt.Errorf("cannot refresh local database routes: %w", localNodeErr)
+		}
+	}
 	knownLocations := make(map[string]databaseLocationSnapshot)
 	openUptimeIntervals := make(map[string]bool)
 	if r.dockerClient != nil && localNodeErr == nil {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -344,6 +344,15 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 		}
 		locationReconciled := false
 		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil {
+			if containerIsLocal && databaseContainerIsRunning(containerState) && (inst.Status == 5 || inst.Status == 12) {
+				if err := reconcileRunningDatabase(ctx, &inst); err != nil {
+					logger.Warn("Failed to reconcile externally started database %s: %v", inst.ID, err)
+				} else {
+					inst.Status = 3
+					route.DBStatus = 3
+					route.Stopped = false
+				}
+			}
 			if containerOwnedLocally && inst.Status == 3 && databaseContainerTerminallyUnavailable(containerState, containerIsLocal) {
 				if err := reconcileStoppedDatabase(ctx, &inst); err != nil {
 					logger.Warn("Failed to reconcile externally stopped database %s: %v", inst.ID, err)
@@ -443,6 +452,10 @@ func databaseContainerTerminallyUnavailable(state string, listedLocally bool) bo
 	}
 }
 
+func databaseContainerIsRunning(state string) bool {
+	return strings.EqualFold(strings.TrimSpace(state), "running")
+}
+
 func databaseUptimeNeedsRepair(instanceStatus int32, containerIsLocal, locationReconciled, intervalOpen bool) bool {
 	return instanceStatus == 3 && containerIsLocal && !locationReconciled && !intervalOpen
 }
@@ -457,6 +470,21 @@ func reconcileStoppedDatabase(ctx context.Context, instance *database.DatabaseIn
 		return fmt.Errorf("update database instance status: %w", err)
 	}
 	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "stopped"); err != nil {
+		return fmt.Errorf("update database location status: %w", err)
+	}
+	return nil
+}
+
+func reconcileRunningDatabase(ctx context.Context, instance *database.DatabaseInstance) error {
+	if instance == nil {
+		return nil
+	}
+	if err := database.DB.WithContext(ctx).Model(&database.DatabaseInstance{}).
+		Where("id = ?", instance.ID).
+		Update("status", 3).Error; err != nil {
+		return fmt.Errorf("update database instance status: %w", err)
+	}
+	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "running"); err != nil {
 		return fmt.Errorf("update database location status: %w", err)
 	}
 	return nil

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -446,12 +446,29 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	r.routesByID = newRoutesByID
 	r.mu.Unlock()
 
-	r.redisMu.Lock()
-	r.usedRedisPorts = newUsedRedisPorts
-	r.redisMu.Unlock()
+	r.replaceRedisReservations(newUsedRedisPorts)
 
 	logger.Info("Loaded %d routes from database", len(instances))
 	return nil
+}
+
+func (r *RouteRegistry) replaceRedisReservations(snapshot map[int]string) {
+	r.redisMu.Lock()
+	defer r.redisMu.Unlock()
+
+	representedDatabases := make(map[string]struct{}, len(snapshot))
+	for _, databaseID := range snapshot {
+		representedDatabases[databaseID] = struct{}{}
+	}
+	for port, databaseID := range r.usedRedisPorts {
+		if _, represented := representedDatabases[databaseID]; represented {
+			continue
+		}
+		if _, occupied := snapshot[port]; !occupied {
+			snapshot[port] = databaseID
+		}
+	}
+	r.usedRedisPorts = snapshot
 }
 
 func (r *RouteRegistry) validRedisPort(port int) bool {

--- a/apps/databases-service/internal/proxy/router.go
+++ b/apps/databases-service/internal/proxy/router.go
@@ -215,11 +215,16 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	newUsedRedisPorts := make(map[int]string)
 	var localNode docker.NodeIdentity
 	var localNodeErr error
+	var localContainerStates map[string]bool
 	if r.dockerClient != nil {
 		localNode, localNodeErr = r.dockerClient.CurrentNodeIdentity(ctx)
+		if localNodeErr == nil {
+			localContainerStates, localNodeErr = r.dockerClient.ManagedDatabaseContainerStates(ctx)
+		}
 	}
 	knownLocations := make(map[string]databaseLocationSnapshot)
-	if localNodeErr == nil {
+	openUptimeIntervals := make(map[string]bool)
+	if r.dockerClient != nil && localNodeErr == nil {
 		containerIDs := make([]string, 0, len(instances))
 		for _, instance := range instances {
 			if instance.InstanceID != nil && *instance.InstanceID != "" {
@@ -238,6 +243,17 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 						NodeHostname: location.NodeHostname,
 						Status:       location.Status,
 					}
+				}
+			}
+			var openIntervalContainerIDs []string
+			if err := database.DB.WithContext(ctx).
+				Model(&database.DatabaseUptimeInterval{}).
+				Where("container_id IN ? AND ended_at IS NULL", containerIDs).
+				Pluck("container_id", &openIntervalContainerIDs).Error; err != nil {
+				localNodeErr = fmt.Errorf("failed to load database uptime intervals: %w", err)
+			} else {
+				for _, containerID := range openIntervalContainerIDs {
+					openUptimeIntervals[containerID] = true
 				}
 			}
 		}
@@ -269,13 +285,26 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 		if inst.InstanceID != nil {
 			route.ContainerID = *inst.InstanceID
 		}
-		locationNeedsReconciliation := databaseLocationNeedsReconciliation(&inst, knownLocations[route.ContainerID], localNode)
-		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil && locationNeedsReconciliation {
-			if _, err := r.dockerClient.ContainerInspect(ctx, route.ContainerID); err == nil {
+		location := knownLocations[route.ContainerID]
+		locationReconciled := false
+		containerIsLocal := false
+		if route.ContainerID != "" && r.dockerClient != nil && localNodeErr == nil {
+			containerRunning := false
+			containerRunning, containerIsLocal = localContainerStates[route.ContainerID]
+			if containerIsLocal && inst.Status == 3 && !containerRunning {
+				if err := reconcileStoppedDatabase(ctx, &inst); err != nil {
+					logger.Warn("Failed to reconcile externally stopped database %s: %v", inst.ID, err)
+				} else {
+					inst.Status = 5
+					route.DBStatus = 5
+					route.Stopped = true
+				}
+			} else if containerIsLocal && databaseLocationNeedsReconciliation(&inst, location, localNode) {
 				r.recordDatabaseLocation(ctx, &inst, localNode)
+				locationReconciled = true
 			}
 		}
-		if inst.Status == 3 {
+		if databaseUptimeNeedsRepair(inst.Status, containerIsLocal, locationReconciled, openUptimeIntervals[route.ContainerID]) {
 			if err := database.EnsureDatabaseUptimeInterval(ctx, inst.ID); err != nil {
 				logger.Warn("Failed to reconcile uptime interval for database %s: %v", inst.ID, err)
 			}
@@ -344,6 +373,25 @@ func (r *RouteRegistry) LoadFromDatabase(ctx context.Context) error {
 	r.redisMu.Unlock()
 
 	logger.Info("Loaded %d routes from database", len(instances))
+	return nil
+}
+
+func databaseUptimeNeedsRepair(instanceStatus int32, containerIsLocal, locationReconciled, intervalOpen bool) bool {
+	return instanceStatus == 3 && containerIsLocal && !locationReconciled && !intervalOpen
+}
+
+func reconcileStoppedDatabase(ctx context.Context, instance *database.DatabaseInstance) error {
+	if instance == nil {
+		return nil
+	}
+	if err := database.DB.WithContext(ctx).Model(&database.DatabaseInstance{}).
+		Where("id = ?", instance.ID).
+		Update("status", 5).Error; err != nil {
+		return fmt.Errorf("update database instance status: %w", err)
+	}
+	if err := database.UpdateDatabaseLocationStatus(ctx, instance.ID, "stopped"); err != nil {
+		return fmt.Errorf("update database location status: %w", err)
+	}
 	return nil
 }
 

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -107,6 +107,42 @@ func TestControlPlaneDatabaseSyncRefreshesRoutes(t *testing.T) {
 	t.Fatal("control-plane route registry did not refresh")
 }
 
+func TestLocalRouteRefreshRetainsSnapshotWithoutNodeDiscovery(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:local-route-refresh-retention?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(&database.DatabaseInstance{}, &database.DatabaseConnection{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	instance := &database.DatabaseInstance{ID: "db-route-retention-test", Type: 1, Status: 3}
+	if err := db.Create(instance).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := db.Create(&database.DatabaseConnection{ID: "conn-route-retention-test", DatabaseID: instance.ID, Port: 5432}).Error; err != nil {
+		t.Fatalf("create database connection: %v", err)
+	}
+
+	registry := NewRouteRegistry(nil)
+	registry.SetLocalRoutesOnly(true)
+	registry.Register(&Route{
+		DatabaseID:   instance.ID,
+		ContainerID:  "container-route-retention-test",
+		ContainerIP:  "obiente-db-route-retention-test",
+		InternalPort: 5432,
+	})
+	if err := registry.LoadFromDatabase(t.Context()); err == nil {
+		t.Fatal("expected local refresh without Docker discovery to fail")
+	}
+	route, ok := registry.LookupByID(instance.ID)
+	if !ok || route.ContainerIP != "obiente-db-route-retention-test" || route.ContainerID != "container-route-retention-test" {
+		t.Fatalf("working route snapshot was replaced: %#v", route)
+	}
+}
+
 func TestDatabaseLocationStatus(t *testing.T) {
 	tests := map[int32]string{
 		0:  "created",

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -2,9 +2,12 @@ package proxy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/obiente/cloud/apps/shared/pkg/database"
 	"github.com/obiente/cloud/apps/shared/pkg/docker"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestDatabaseLocationStatus(t *testing.T) {
@@ -28,6 +31,90 @@ func TestDatabaseLocationStatus(t *testing.T) {
 		if got := databaseLocationStatus(status); got != want {
 			t.Errorf("databaseLocationStatus(%d) = %q, want %q", status, got, want)
 		}
+	}
+}
+
+func TestDatabaseUptimeNeedsRepairOnlyForMissingLocalInterval(t *testing.T) {
+	if databaseUptimeNeedsRepair(3, true, false, true) {
+		t.Fatal("healthy open interval unexpectedly needs repair")
+	}
+	if databaseUptimeNeedsRepair(3, false, false, false) {
+		t.Fatal("remote database unexpectedly needs local interval repair")
+	}
+	if databaseUptimeNeedsRepair(3, true, true, false) {
+		t.Fatal("location upsert already repaired the missing interval")
+	}
+	if !databaseUptimeNeedsRepair(3, true, false, false) {
+		t.Fatal("missing local running interval did not request repair")
+	}
+}
+
+func TestReconcileStoppedDatabaseClosesTracking(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:proxy-stopped-reconciliation?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(
+		&database.DatabaseInstance{},
+		&database.DatabaseLocation{},
+		&database.DatabaseUptimeInterval{},
+	); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	databaseID := "db-external-stop-test"
+	containerID := "container-external-stop-test"
+	instance := &database.DatabaseInstance{ID: databaseID, InstanceID: &containerID, Status: 3}
+	if err := db.Create(instance).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := db.Create(&database.DatabaseLocation{
+		ID:          database.DatabaseLocationID(databaseID, containerID),
+		DatabaseID:  databaseID,
+		NodeID:      "node-external-stop-test",
+		ContainerID: containerID,
+		Status:      "running",
+	}).Error; err != nil {
+		t.Fatalf("create database location: %v", err)
+	}
+	if err := db.Create(&database.DatabaseUptimeInterval{
+		ID:          "interval-external-stop-test",
+		DatabaseID:  databaseID,
+		ContainerID: containerID,
+		NodeID:      "node-external-stop-test",
+		StartedAt:   time.Now().Add(-time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("create uptime interval: %v", err)
+	}
+
+	if err := reconcileStoppedDatabase(t.Context(), instance); err != nil {
+		t.Fatalf("reconcile stopped database: %v", err)
+	}
+	var storedInstance database.DatabaseInstance
+	if err := db.First(&storedInstance, "id = ?", databaseID).Error; err != nil {
+		t.Fatalf("load database instance: %v", err)
+	}
+	if storedInstance.Status != 5 {
+		t.Fatalf("database status = %d, want stopped", storedInstance.Status)
+	}
+	var storedLocation database.DatabaseLocation
+	if err := db.First(&storedLocation, "container_id = ?", containerID).Error; err != nil {
+		t.Fatalf("load database location: %v", err)
+	}
+	if storedLocation.Status != "stopped" {
+		t.Fatalf("location status = %q, want stopped", storedLocation.Status)
+	}
+	var openIntervals int64
+	if err := db.Model(&database.DatabaseUptimeInterval{}).
+		Where("database_id = ? AND ended_at IS NULL", databaseID).
+		Count(&openIntervals).Error; err != nil {
+		t.Fatalf("count open uptime intervals: %v", err)
+	}
+	if openIntervals != 0 {
+		t.Fatalf("open uptime intervals = %d, want 0", openIntervals)
 	}
 }
 

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -59,6 +59,54 @@ func TestLoadFromDatabasePreservesAndBackfillsRedisProxyPorts(t *testing.T) {
 	}
 }
 
+func TestControlPlaneDatabaseSyncRefreshesRoutes(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:control-plane-route-sync?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(&database.DatabaseInstance{}, &database.DatabaseConnection{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	registry := NewRouteRegistry(nil)
+	syncCtx, cancel := context.WithCancel(t.Context())
+	done := registry.StartDatabaseSync(syncCtx, 5*time.Millisecond)
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("control-plane route sync did not stop")
+		}
+	})
+
+	instance := &database.DatabaseInstance{ID: "db-control-plane-sync-test", Type: 1, Status: 12}
+	if err := db.Create(instance).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := db.Create(&database.DatabaseConnection{
+		ID:         "conn-control-plane-sync-test",
+		DatabaseID: instance.ID,
+		Username:   "test-user",
+		Password:   "test-secret",
+		Port:       5432,
+	}).Error; err != nil {
+		t.Fatalf("create database connection: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if route, ok := registry.LookupByID(instance.ID); ok && route.Stopped && route.DBStatus == 12 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("control-plane route registry did not refresh")
+}
+
 func TestDatabaseLocationStatus(t *testing.T) {
 	tests := map[int32]string{
 		0:  "created",

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -1,0 +1,27 @@
+package proxy
+
+import "testing"
+
+func TestDatabaseLocationStatus(t *testing.T) {
+	tests := map[int32]string{
+		0:  "created",
+		1:  "creating",
+		2:  "starting",
+		3:  "running",
+		4:  "stopping",
+		5:  "stopped",
+		6:  "backing_up",
+		7:  "restoring",
+		8:  "failed",
+		9:  "deleting",
+		10: "deleted",
+		11: "suspended",
+		12: "sleeping",
+	}
+
+	for status, want := range tests {
+		if got := databaseLocationStatus(status); got != want {
+			t.Errorf("databaseLocationStatus(%d) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,6 +10,54 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestLoadFromDatabasePreservesAndBackfillsRedisProxyPorts(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:redis-proxy-port-routing?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(&database.DatabaseInstance{}, &database.DatabaseConnection{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	instances := []database.DatabaseInstance{
+		{ID: "db-redis-existing", Type: 4, Status: 3},
+		{ID: "db-redis-legacy", Type: 4, Status: 3},
+	}
+	if err := db.Create(&instances).Error; err != nil {
+		t.Fatalf("create Redis instances: %v", err)
+	}
+	connections := []database.DatabaseConnection{
+		{ID: "conn-redis-existing", DatabaseID: instances[0].ID, ProxyPort: 16380},
+		{ID: "conn-redis-legacy", DatabaseID: instances[1].ID},
+	}
+	if err := db.Create(&connections).Error; err != nil {
+		t.Fatalf("create Redis connections: %v", err)
+	}
+
+	registry := NewRouteRegistry(nil)
+	if err := registry.LoadFromDatabase(context.Background()); err != nil {
+		t.Fatalf("load Redis routes: %v", err)
+	}
+	existingRoute, ok := registry.LookupByID(instances[0].ID)
+	if !ok || existingRoute.RedisPort != 16380 {
+		t.Fatalf("persisted Redis proxy port was not preserved: %#v", existingRoute)
+	}
+	legacyRoute, ok := registry.LookupByID(instances[1].ID)
+	if !ok || legacyRoute.RedisPort == 0 || legacyRoute.RedisPort == existingRoute.RedisPort {
+		t.Fatalf("legacy Redis proxy port was not uniquely backfilled: %#v", legacyRoute)
+	}
+	var storedLegacy database.DatabaseConnection
+	if err := db.First(&storedLegacy, "database_id = ?", instances[1].ID).Error; err != nil {
+		t.Fatalf("load backfilled Redis connection: %v", err)
+	}
+	if int(storedLegacy.ProxyPort) != legacyRoute.RedisPort {
+		t.Fatalf("stored proxy port %d does not match route %d", storedLegacy.ProxyPort, legacyRoute.RedisPort)
+	}
+}
 
 func TestDatabaseLocationStatus(t *testing.T) {
 	tests := map[int32]string{

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -1,6 +1,11 @@
 package proxy
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/obiente/cloud/apps/shared/pkg/database"
+	"github.com/obiente/cloud/apps/shared/pkg/docker"
+)
 
 func TestDatabaseLocationStatus(t *testing.T) {
 	tests := map[int32]string{
@@ -23,5 +28,53 @@ func TestDatabaseLocationStatus(t *testing.T) {
 		if got := databaseLocationStatus(status); got != want {
 			t.Errorf("databaseLocationStatus(%d) = %q, want %q", status, got, want)
 		}
+	}
+}
+
+func TestDatabaseLocationNeedsReconciliation(t *testing.T) {
+	nodeID := "node-routing-test"
+	instance := &database.DatabaseInstance{NodeID: &nodeID, Status: 3}
+	localNode := docker.NodeIdentity{
+		ID:       nodeID,
+		IP:       "192.0.2.10",
+		Hostname: "routing-host",
+	}
+	current := databaseLocationSnapshot{
+		NodeID:       nodeID,
+		NodeIP:       localNode.IP,
+		NodeHostname: localNode.Hostname,
+		Status:       "running",
+	}
+
+	if databaseLocationNeedsReconciliation(instance, current, localNode) {
+		t.Fatal("current location unexpectedly needs reconciliation")
+	}
+
+	tests := map[string]databaseLocationSnapshot{
+		"changed address": {
+			NodeID:       nodeID,
+			NodeIP:       "198.51.100.20",
+			NodeHostname: localNode.Hostname,
+			Status:       "running",
+		},
+		"changed hostname": {
+			NodeID:       nodeID,
+			NodeIP:       localNode.IP,
+			NodeHostname: "old-routing-host",
+			Status:       "running",
+		},
+		"stale status": {
+			NodeID:       nodeID,
+			NodeIP:       localNode.IP,
+			NodeHostname: localNode.Hostname,
+			Status:       "starting",
+		},
+	}
+	for name, location := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !databaseLocationNeedsReconciliation(instance, location, localNode) {
+				t.Fatal("stale location did not request reconciliation")
+			}
+		})
 	}
 }

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -49,6 +49,25 @@ func TestDatabaseUptimeNeedsRepairOnlyForMissingLocalInterval(t *testing.T) {
 	}
 }
 
+func TestDatabaseContainerOwnedLocallyUsesPersistedOwnerForMissingContainer(t *testing.T) {
+	localNodeID := "node-local-owner-test"
+	instance := &database.DatabaseInstance{NodeID: &localNodeID}
+	location := databaseLocationSnapshot{NodeID: localNodeID}
+	if !databaseContainerOwnedLocally(instance, location, localNodeID, false) {
+		t.Fatal("missing container with a persisted local owner was treated as remote")
+	}
+
+	remoteNodeID := "node-remote-owner-test"
+	remoteInstance := &database.DatabaseInstance{NodeID: &remoteNodeID}
+	remoteLocation := databaseLocationSnapshot{NodeID: remoteNodeID}
+	if databaseContainerOwnedLocally(remoteInstance, remoteLocation, localNodeID, false) {
+		t.Fatal("remote container was treated as locally owned")
+	}
+	if !databaseContainerOwnedLocally(remoteInstance, remoteLocation, localNodeID, true) {
+		t.Fatal("locally listed container did not override stale ownership metadata")
+	}
+}
+
 func TestReconcileStoppedDatabaseClosesTracking(t *testing.T) {
 	previousDB := database.DB
 	db, err := gorm.Open(sqlite.Open("file:proxy-stopped-reconciliation?mode=memory&cache=shared"), &gorm.Config{})

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -66,6 +66,27 @@ func TestDatabaseContainerOwnedLocallyUsesPersistedOwnerForMissingContainer(t *t
 	if !databaseContainerOwnedLocally(remoteInstance, remoteLocation, localNodeID, true) {
 		t.Fatal("locally listed container did not override stale ownership metadata")
 	}
+
+	staleInstance := &database.DatabaseInstance{NodeID: &localNodeID}
+	if databaseContainerOwnedLocally(staleInstance, remoteLocation, localNodeID, false) {
+		t.Fatal("stale instance owner overrode the authoritative location owner")
+	}
+}
+
+func TestDatabaseContainerTerminallyUnavailableIgnoresTransientStates(t *testing.T) {
+	for _, state := range []string{"running", "restarting", "created", "paused", "removing"} {
+		if databaseContainerTerminallyUnavailable(state, true) {
+			t.Fatalf("transient container state %q was treated as terminal", state)
+		}
+	}
+	for _, state := range []string{"exited", "dead"} {
+		if !databaseContainerTerminallyUnavailable(state, true) {
+			t.Fatalf("terminal container state %q was not reconciled", state)
+		}
+	}
+	if !databaseContainerTerminallyUnavailable("", false) {
+		t.Fatal("missing locally owned container was not treated as terminal")
+	}
 }
 
 func TestReconcileStoppedDatabaseClosesTracking(t *testing.T) {

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -59,6 +59,24 @@ func TestLoadFromDatabasePreservesAndBackfillsRedisProxyPorts(t *testing.T) {
 	}
 }
 
+func TestRedisRefreshPreservesInflightPortReservation(t *testing.T) {
+	registry := NewRouteRegistry(nil)
+	registry.usedRedisPorts[16379] = "db-redis-creating"
+	registry.usedRedisPorts[16381] = "db-redis-running"
+
+	registry.replaceRedisReservations(map[int]string{16380: "db-redis-running"})
+
+	if got := registry.usedRedisPorts[16379]; got != "db-redis-creating" {
+		t.Fatalf("in-flight reservation owner = %q, want db-redis-creating", got)
+	}
+	if got := registry.usedRedisPorts[16380]; got != "db-redis-running" {
+		t.Fatalf("persisted reservation owner = %q, want db-redis-running", got)
+	}
+	if _, exists := registry.usedRedisPorts[16381]; exists {
+		t.Fatal("stale reservation for a persisted database was retained")
+	}
+}
+
 func TestControlPlaneDatabaseSyncRefreshesRoutes(t *testing.T) {
 	previousDB := database.DB
 	db, err := gorm.Open(sqlite.Open("file:control-plane-route-sync?mode=memory&cache=shared"), &gorm.Config{})

--- a/apps/databases-service/internal/proxy/router_test.go
+++ b/apps/databases-service/internal/proxy/router_test.go
@@ -207,6 +207,69 @@ func TestReconcileStoppedDatabaseClosesTracking(t *testing.T) {
 	}
 }
 
+func TestReconcileRunningDatabaseReopensTracking(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:proxy-running-reconciliation?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(
+		&database.DatabaseInstance{},
+		&database.DatabaseLocation{},
+		&database.DatabaseUptimeInterval{},
+	); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	databaseID := "db-external-start-test"
+	containerID := "container-external-start-test"
+	instance := &database.DatabaseInstance{ID: databaseID, InstanceID: &containerID, Status: 12}
+	if err := db.Create(instance).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := db.Create(&database.DatabaseLocation{
+		ID:          database.DatabaseLocationID(databaseID, containerID),
+		DatabaseID:  databaseID,
+		NodeID:      "node-external-start-test",
+		ContainerID: containerID,
+		Status:      "sleeping",
+	}).Error; err != nil {
+		t.Fatalf("create sleeping database location: %v", err)
+	}
+
+	if !databaseContainerIsRunning(" running ") {
+		t.Fatal("running container state was not recognized")
+	}
+	if err := reconcileRunningDatabase(t.Context(), instance); err != nil {
+		t.Fatalf("reconcile running database: %v", err)
+	}
+	var storedInstance database.DatabaseInstance
+	if err := db.First(&storedInstance, "id = ?", databaseID).Error; err != nil {
+		t.Fatalf("load database instance: %v", err)
+	}
+	if storedInstance.Status != 3 {
+		t.Fatalf("database status = %d, want running", storedInstance.Status)
+	}
+	var storedLocation database.DatabaseLocation
+	if err := db.First(&storedLocation, "container_id = ?", containerID).Error; err != nil {
+		t.Fatalf("load database location: %v", err)
+	}
+	if storedLocation.Status != "running" {
+		t.Fatalf("location status = %q, want running", storedLocation.Status)
+	}
+	var openIntervals int64
+	if err := db.Model(&database.DatabaseUptimeInterval{}).
+		Where("database_id = ? AND ended_at IS NULL", databaseID).
+		Count(&openIntervals).Error; err != nil {
+		t.Fatalf("count open uptime intervals: %v", err)
+	}
+	if openIntervals != 1 {
+		t.Fatalf("open uptime intervals = %d, want 1", openIntervals)
+	}
+}
+
 func TestDatabaseLocationNeedsReconciliation(t *testing.T) {
 	nodeID := "node-routing-test"
 	instance := &database.DatabaseInstance{NodeID: &nodeID, Status: 3}

--- a/apps/databases-service/internal/service/connection.go
+++ b/apps/databases-service/internal/service/connection.go
@@ -70,14 +70,17 @@ func (s *Service) GetDatabaseConnectionInfo(ctx context.Context, req *connect.Re
 	case databasesv1.DatabaseType_MONGODB:
 		externalPort = 27017
 	case databasesv1.DatabaseType_REDIS:
-		// Use allocated port from registry
-		if s.routeRegistry != nil {
+		if conn.ProxyPort > 0 {
+			externalPort = conn.ProxyPort
+		} else if s.routeRegistry != nil {
+			// Legacy records are backfilled by the route registry on first load.
 			if route, ok := s.routeRegistry.LookupByID(req.Msg.GetDatabaseId()); ok && route.RedisPort > 0 {
 				externalPort = int32(route.RedisPort)
 			} else {
 				if err := s.routeRegistry.LoadFromDatabase(ctx); err == nil {
 					if route, ok := s.routeRegistry.LookupByID(req.Msg.GetDatabaseId()); ok && route.RedisPort > 0 {
 						externalPort = int32(route.RedisPort)
+						conn.ProxyPort = externalPort
 						break
 					}
 				}

--- a/apps/databases-service/internal/service/crud.go
+++ b/apps/databases-service/internal/service/crud.go
@@ -385,19 +385,33 @@ func (s *Service) failUnpublishedDatabase(ctx context.Context, instance *databas
 	if redisPort > 0 && s.routeRegistry != nil {
 		s.routeRegistry.ReleaseRedisPort(int(redisPort))
 	}
+	containerRemoved := containerID == ""
 	if s.provisioner != nil && containerID != "" {
-		if err := s.provisioner.DeprovisionDatabase(ctx, containerID); err != nil {
+		cleanupCtx, cleanupCancel := s.detachedContext(2 * time.Minute)
+		if err := s.provisioner.DeprovisionDatabase(cleanupCtx, containerID); err != nil {
 			logger.Error("Failed to remove unpublished database container %s: %v", containerID, err)
+		} else {
+			containerRemoved = true
 		}
+		cleanupCancel()
 	}
 	if instance == nil {
 		return
 	}
-	instance.Status = 8 // FAILED
-	instance.InstanceID = nil
-	instance.NodeID = nil
+	markUnpublishedDatabaseFailed(instance, containerRemoved)
 	if err := s.persistDatabaseInstance(ctx, instance); err != nil {
 		logger.Error("Failed to persist failed database provisioning state: %v", err)
+	}
+}
+
+func markUnpublishedDatabaseFailed(instance *database.DatabaseInstance, containerRemoved bool) {
+	if instance == nil {
+		return
+	}
+	instance.Status = 8 // FAILED
+	if containerRemoved {
+		instance.InstanceID = nil
+		instance.NodeID = nil
 	}
 }
 

--- a/apps/databases-service/internal/service/crud.go
+++ b/apps/databases-service/internal/service/crud.go
@@ -507,6 +507,7 @@ func (s *Service) DeleteDatabase(ctx context.Context, req *connect.Request[datab
 		// Update status to DELETING
 		dbInstance.Status = 9 // DELETING
 		s.repo.Update(deleteCtx, dbInstance)
+		updateDatabaseLocationStatus(deleteCtx, dbInstance.ID, "deleting")
 
 		// Unregister route from proxy
 		if s.routeRegistry != nil {

--- a/apps/databases-service/internal/service/crud.go
+++ b/apps/databases-service/internal/service/crud.go
@@ -258,7 +258,21 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 		dbInstance.InstanceID = &result.ContainerID
 		dbInstance.Host = &result.Host
 		dbInstance.Port = &port
+		dbInstance.NodeID = &result.NodeID
 		dbInstance.Status = 3 // RUNNING
+
+		if err := database.UpsertDatabaseLocation(&database.DatabaseLocation{
+			ID:           database.DatabaseLocationID(id, result.ContainerID),
+			DatabaseID:   id,
+			NodeID:       result.NodeID,
+			NodeHostname: result.NodeHostname,
+			NodeIP:       result.NodeIP,
+			ContainerID:  result.ContainerID,
+			Status:       "running",
+			Port:         port,
+		}); err != nil {
+			logger.Warn("Failed to record database location: %v", err)
+		}
 
 		// Create connection record
 		connID := fmt.Sprintf("conn-%s", uuid.NewString())

--- a/apps/databases-service/internal/service/crud.go
+++ b/apps/databases-service/internal/service/crud.go
@@ -261,19 +261,6 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 		dbInstance.NodeID = &result.NodeID
 		dbInstance.Status = 3 // RUNNING
 
-		if err := database.UpsertDatabaseLocation(&database.DatabaseLocation{
-			ID:           database.DatabaseLocationID(id, result.ContainerID),
-			DatabaseID:   id,
-			NodeID:       result.NodeID,
-			NodeHostname: result.NodeHostname,
-			NodeIP:       result.NodeIP,
-			ContainerID:  result.ContainerID,
-			Status:       "running",
-			Port:         port,
-		}); err != nil {
-			logger.Warn("Failed to record database location: %v", err)
-		}
-
 		// Create connection record
 		connID := fmt.Sprintf("conn-%s", uuid.NewString())
 
@@ -306,13 +293,31 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 			}
 		}
 
-		if err := s.connRepo.Create(provisionCtx, dbConn); err != nil {
-			logger.Warn("Failed to create connection record: %v", err)
+		if err := s.persistDatabaseConnection(provisionCtx, dbConn); err != nil {
+			logger.Error("Failed to persist connection record; removing unpublished database container: %v", err)
+			s.failUnpublishedDatabase(provisionCtx, dbInstance, result.ContainerID, dbConn.ProxyPort)
+			return
 		}
 
-		// Update database with final status
-		if err := s.repo.Update(provisionCtx, dbInstance); err != nil {
-			logger.Error("Failed to update database instance: %v", err)
+		// Persist the authoritative instance before publishing a running location.
+		if err := s.persistDatabaseInstance(provisionCtx, dbInstance); err != nil {
+			logger.Error("Failed to persist running database instance; removing unpublished database container: %v", err)
+			_ = s.connRepo.Delete(provisionCtx, id)
+			s.failUnpublishedDatabase(provisionCtx, dbInstance, result.ContainerID, dbConn.ProxyPort)
+			return
+		}
+
+		if err := database.UpsertDatabaseLocation(&database.DatabaseLocation{
+			ID:           database.DatabaseLocationID(id, result.ContainerID),
+			DatabaseID:   id,
+			NodeID:       result.NodeID,
+			NodeHostname: result.NodeHostname,
+			NodeIP:       result.NodeIP,
+			ContainerID:  result.ContainerID,
+			Status:       "running",
+			Port:         port,
+		}); err != nil {
+			logger.Warn("Failed to record database location: %v", err)
 		}
 
 		// Register route in proxy
@@ -374,6 +379,26 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 		ConnectionInfo: createConnInfo,
 	})
 	return res, nil
+}
+
+func (s *Service) failUnpublishedDatabase(ctx context.Context, instance *database.DatabaseInstance, containerID string, redisPort int32) {
+	if redisPort > 0 && s.routeRegistry != nil {
+		s.routeRegistry.ReleaseRedisPort(int(redisPort))
+	}
+	if s.provisioner != nil && containerID != "" {
+		if err := s.provisioner.DeprovisionDatabase(ctx, containerID); err != nil {
+			logger.Error("Failed to remove unpublished database container %s: %v", containerID, err)
+		}
+	}
+	if instance == nil {
+		return
+	}
+	instance.Status = 8 // FAILED
+	instance.InstanceID = nil
+	instance.NodeID = nil
+	if err := s.persistDatabaseInstance(ctx, instance); err != nil {
+		logger.Error("Failed to persist failed database provisioning state: %v", err)
+	}
 }
 
 // GetDatabase gets a database instance by ID

--- a/apps/databases-service/internal/service/crud.go
+++ b/apps/databases-service/internal/service/crud.go
@@ -297,6 +297,14 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 			Port:         port,
 			SSLRequired:  true,
 		}
+		if req.Msg.GetType() == databasesv1.DatabaseType_REDIS && s.routeRegistry != nil {
+			redisPort, err := s.routeRegistry.AllocateRedisPort(id)
+			if err != nil {
+				logger.Error("Failed to allocate Redis port: %v", err)
+			} else {
+				dbConn.ProxyPort = int32(redisPort)
+			}
+		}
 
 		if err := s.connRepo.Create(provisionCtx, dbConn); err != nil {
 			logger.Warn("Failed to create connection record: %v", err)
@@ -329,17 +337,13 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 
 			// Allocate Redis port if needed
 			if dbType == "redis" {
-				if redisPort, err := s.routeRegistry.AllocateRedisPort(id); err == nil {
-					route.RedisPort = redisPort
-				} else {
-					logger.Error("Failed to allocate Redis port: %v", err)
-				}
+				route.RedisPort = int(dbConn.ProxyPort)
 			}
 
 			s.routeRegistry.Register(route)
 
 			// Start Redis listener if needed
-			if route.RedisPort > 0 && s.proxy != nil {
+			if route.RedisPort > 0 && s.proxy != nil && s.proxyEnabled {
 				if err := s.proxy.StartRedisListener(route); err != nil {
 					logger.Error("Failed to start Redis listener: %v", err)
 				}

--- a/apps/databases-service/internal/service/crud.go
+++ b/apps/databases-service/internal/service/crud.go
@@ -295,7 +295,7 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 
 		if err := s.persistDatabaseConnection(provisionCtx, dbConn); err != nil {
 			logger.Error("Failed to persist connection record; removing unpublished database container: %v", err)
-			s.failUnpublishedDatabase(provisionCtx, dbInstance, result.ContainerID, dbConn.ProxyPort)
+			s.failUnpublishedDatabase(dbInstance, result.ContainerID, dbConn.ProxyPort)
 			return
 		}
 
@@ -303,7 +303,7 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 		if err := s.persistDatabaseInstance(provisionCtx, dbInstance); err != nil {
 			logger.Error("Failed to persist running database instance; removing unpublished database container: %v", err)
 			_ = s.connRepo.Delete(provisionCtx, id)
-			s.failUnpublishedDatabase(provisionCtx, dbInstance, result.ContainerID, dbConn.ProxyPort)
+			s.failUnpublishedDatabase(dbInstance, result.ContainerID, dbConn.ProxyPort)
 			return
 		}
 
@@ -381,7 +381,7 @@ func (s *Service) CreateDatabase(ctx context.Context, req *connect.Request[datab
 	return res, nil
 }
 
-func (s *Service) failUnpublishedDatabase(ctx context.Context, instance *database.DatabaseInstance, containerID string, redisPort int32) {
+func (s *Service) failUnpublishedDatabase(instance *database.DatabaseInstance, containerID string, redisPort int32) {
 	if redisPort > 0 && s.routeRegistry != nil {
 		s.routeRegistry.ReleaseRedisPort(int(redisPort))
 	}
@@ -399,7 +399,9 @@ func (s *Service) failUnpublishedDatabase(ctx context.Context, instance *databas
 		return
 	}
 	markUnpublishedDatabaseFailed(instance, containerRemoved)
-	if err := s.persistDatabaseInstance(ctx, instance); err != nil {
+	failedCtx, failedCancel := s.detachedContext(30 * time.Second)
+	defer failedCancel()
+	if err := s.persistDatabaseInstance(failedCtx, instance); err != nil {
 		logger.Error("Failed to persist failed database provisioning state: %v", err)
 	}
 }

--- a/apps/databases-service/internal/service/lifecycle.go
+++ b/apps/databases-service/internal/service/lifecycle.go
@@ -304,6 +304,15 @@ func (s *Service) persistDatabaseInstance(ctx context.Context, dbInstance *datab
 	})
 }
 
+func (s *Service) persistDatabaseConnection(ctx context.Context, connection *database.DatabaseConnection) error {
+	if s == nil || s.connRepo == nil {
+		return fmt.Errorf("database connection repository is unavailable")
+	}
+	return retryDatabaseWrite(ctx, 5, 250*time.Millisecond, func() error {
+		return s.connRepo.CreateOrUpdate(ctx, connection)
+	})
+}
+
 func retryDatabaseWrite(ctx context.Context, attempts int, delay time.Duration, update func() error) error {
 	if attempts < 1 {
 		attempts = 1

--- a/apps/databases-service/internal/service/lifecycle.go
+++ b/apps/databases-service/internal/service/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/obiente/cloud/apps/shared/pkg/auth"
+	"github.com/obiente/cloud/apps/shared/pkg/database"
 	"github.com/obiente/cloud/apps/shared/pkg/logger"
 
 	databasesv1 "github.com/obiente/cloud/apps/shared/proto/obiente/cloud/databases/v1"
@@ -43,6 +44,7 @@ func (s *Service) StartDatabase(ctx context.Context, req *connect.Request[databa
 	if err := s.repo.Update(ctx, dbInstance); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to start database: %w", err))
 	}
+	updateDatabaseLocationStatus(ctx, dbInstance.ID, "starting")
 
 	// Start the database container asynchronously
 	go func() {
@@ -54,6 +56,7 @@ func (s *Service) StartDatabase(ctx context.Context, req *connect.Request[databa
 				logger.Error("Failed to start database container: %v", err)
 				dbInstance.Status = 8 // FAILED
 				s.repo.Update(startCtx, dbInstance)
+				updateDatabaseLocationStatus(startCtx, dbInstance.ID, "failed")
 				return
 			}
 		}
@@ -64,6 +67,7 @@ func (s *Service) StartDatabase(ctx context.Context, req *connect.Request[databa
 		if err := s.repo.Update(startCtx, dbInstance); err != nil {
 			logger.Error("Failed to update database status: %v", err)
 		}
+		updateDatabaseLocationStatus(startCtx, dbInstance.ID, "running")
 
 		// Update route registry
 		if s.routeRegistry != nil {
@@ -110,6 +114,7 @@ func (s *Service) StopDatabase(ctx context.Context, req *connect.Request[databas
 	if err := s.repo.Update(ctx, dbInstance); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to stop database: %w", err))
 	}
+	updateDatabaseLocationStatus(ctx, dbInstance.ID, "stopping")
 
 	// Stop the database container asynchronously
 	go func() {
@@ -121,6 +126,7 @@ func (s *Service) StopDatabase(ctx context.Context, req *connect.Request[databas
 				logger.Error("Failed to stop database container: %v", err)
 				dbInstance.Status = 8 // FAILED
 				s.repo.Update(stopCtx, dbInstance)
+				updateDatabaseLocationStatus(stopCtx, dbInstance.ID, "failed")
 				return
 			}
 		}
@@ -130,6 +136,7 @@ func (s *Service) StopDatabase(ctx context.Context, req *connect.Request[databas
 		if err := s.repo.Update(stopCtx, dbInstance); err != nil {
 			logger.Error("Failed to update database status: %v", err)
 		}
+		updateDatabaseLocationStatus(stopCtx, dbInstance.ID, "stopped")
 
 		// Update route registry - STOPPED means no auto-wake
 		if s.routeRegistry != nil {
@@ -175,6 +182,7 @@ func (s *Service) RestartDatabase(ctx context.Context, req *connect.Request[data
 	if err := s.repo.Update(ctx, dbInstance); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to restart database: %w", err))
 	}
+	updateDatabaseLocationStatus(ctx, dbInstance.ID, "starting")
 
 	// Restart the database container asynchronously
 	go func() {
@@ -186,6 +194,7 @@ func (s *Service) RestartDatabase(ctx context.Context, req *connect.Request[data
 				logger.Error("Failed to restart database container: %v", err)
 				dbInstance.Status = 8 // FAILED
 				s.repo.Update(restartCtx, dbInstance)
+				updateDatabaseLocationStatus(restartCtx, dbInstance.ID, "failed")
 				return
 			}
 		}
@@ -196,6 +205,7 @@ func (s *Service) RestartDatabase(ctx context.Context, req *connect.Request[data
 		if err := s.repo.Update(restartCtx, dbInstance); err != nil {
 			logger.Error("Failed to update database status: %v", err)
 		}
+		updateDatabaseLocationStatus(restartCtx, dbInstance.ID, "running")
 	}()
 
 	protoDB := dbDatabaseToProto(dbInstance)
@@ -236,6 +246,7 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 	if err := s.repo.Update(ctx, dbInstance); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to sleep database: %w", err))
 	}
+	updateDatabaseLocationStatus(ctx, dbInstance.ID, "stopping")
 
 	// Stop the database container asynchronously
 	go func() {
@@ -247,6 +258,7 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 				logger.Error("Failed to stop database container for sleep: %v", err)
 				dbInstance.Status = 8 // FAILED
 				s.repo.Update(sleepCtx, dbInstance)
+				updateDatabaseLocationStatus(sleepCtx, dbInstance.ID, "failed")
 				return
 			}
 		}
@@ -256,6 +268,7 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 		if err := s.repo.Update(sleepCtx, dbInstance); err != nil {
 			logger.Error("Failed to update database status: %v", err)
 		}
+		updateDatabaseLocationStatus(sleepCtx, dbInstance.ID, "sleeping")
 
 		// Update route registry - SLEEPING means auto-wake on connect
 		if s.routeRegistry != nil {
@@ -274,4 +287,10 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 // Helper function
 func timePtr(t time.Time) *time.Time {
 	return &t
+}
+
+func updateDatabaseLocationStatus(ctx context.Context, databaseID, status string) {
+	if err := database.UpdateDatabaseLocationStatus(ctx, databaseID, status); err != nil {
+		logger.Warn("Failed to update database %s location status to %s: %v", databaseID, status, err)
+	}
 }

--- a/apps/databases-service/internal/service/lifecycle.go
+++ b/apps/databases-service/internal/service/lifecycle.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"databases-service/internal/proxy"
+
 	"github.com/obiente/cloud/apps/shared/pkg/auth"
 	"github.com/obiente/cloud/apps/shared/pkg/database"
 	"github.com/obiente/cloud/apps/shared/pkg/logger"
@@ -242,11 +244,9 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("database not found"))
 	}
 
-	// Update status to STOPPING temporarily
+	// Report STOPPING to the caller, but retain durable RUNNING until Docker has
+	// stopped and the wakeable SLEEPING transition can be committed.
 	dbInstance.Status = 4 // STOPPING
-	if err := s.repo.Update(ctx, dbInstance); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to sleep database: %w", err))
-	}
 	updateDatabaseLocationStatus(ctx, dbInstance.ID, "stopping")
 
 	// Stop the database container asynchronously
@@ -265,7 +265,10 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 		// Update status to SLEEPING (not STOPPED)
 		dbInstance.Status = 12 // SLEEPING
 		if err := s.persistDatabaseInstance(sleepCtx, dbInstance); err != nil {
-			logger.Error("Failed to persist sleeping database status: %v", err)
+			logger.Error("Failed to persist sleeping database status: %v", s.recoverAfterSleepingWriteFailure(dbInstance, &proxy.Route{
+				DatabaseID:  dbInstance.ID,
+				ContainerID: valueOrEmpty(dbInstance.InstanceID),
+			}, err))
 			return
 		}
 		updateDatabaseLocationStatus(sleepCtx, dbInstance.ID, "sleeping")
@@ -282,6 +285,13 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 		Database: protoDB,
 	})
 	return res, nil
+}
+
+func valueOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func (s *Service) restoreDatabaseAfterFailedStop(ctx context.Context, dbInstance *database.DatabaseInstance) {

--- a/apps/databases-service/internal/service/lifecycle.go
+++ b/apps/databases-service/internal/service/lifecycle.go
@@ -64,8 +64,9 @@ func (s *Service) StartDatabase(ctx context.Context, req *connect.Request[databa
 		// Update status to RUNNING
 		dbInstance.Status = 3 // RUNNING
 		dbInstance.LastStartedAt = timePtr(time.Now())
-		if err := s.repo.Update(startCtx, dbInstance); err != nil {
-			logger.Error("Failed to update database status: %v", err)
+		if err := s.persistDatabaseInstance(startCtx, dbInstance); err != nil {
+			logger.Error("Failed to persist running database status: %v", err)
+			return
 		}
 		updateDatabaseLocationStatus(startCtx, dbInstance.ID, "running")
 
@@ -131,8 +132,9 @@ func (s *Service) StopDatabase(ctx context.Context, req *connect.Request[databas
 
 		// Update status to STOPPED
 		dbInstance.Status = 5 // STOPPED
-		if err := s.repo.Update(stopCtx, dbInstance); err != nil {
-			logger.Error("Failed to update database status: %v", err)
+		if err := s.persistDatabaseInstance(stopCtx, dbInstance); err != nil {
+			logger.Error("Failed to persist stopped database status: %v", err)
+			return
 		}
 		updateDatabaseLocationStatus(stopCtx, dbInstance.ID, "stopped")
 
@@ -200,8 +202,9 @@ func (s *Service) RestartDatabase(ctx context.Context, req *connect.Request[data
 		// Update status to RUNNING
 		dbInstance.Status = 3 // RUNNING
 		dbInstance.LastStartedAt = timePtr(time.Now())
-		if err := s.repo.Update(restartCtx, dbInstance); err != nil {
-			logger.Error("Failed to update database status: %v", err)
+		if err := s.persistDatabaseInstance(restartCtx, dbInstance); err != nil {
+			logger.Error("Failed to persist running database status after restart: %v", err)
+			return
 		}
 		updateDatabaseLocationStatus(restartCtx, dbInstance.ID, "running")
 	}()
@@ -261,8 +264,9 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 
 		// Update status to SLEEPING (not STOPPED)
 		dbInstance.Status = 12 // SLEEPING
-		if err := s.repo.Update(sleepCtx, dbInstance); err != nil {
-			logger.Error("Failed to update database status: %v", err)
+		if err := s.persistDatabaseInstance(sleepCtx, dbInstance); err != nil {
+			logger.Error("Failed to persist sleeping database status: %v", err)
+			return
 		}
 		updateDatabaseLocationStatus(sleepCtx, dbInstance.ID, "sleeping")
 
@@ -289,6 +293,40 @@ func (s *Service) restoreDatabaseAfterFailedStop(ctx context.Context, dbInstance
 		logger.Error("Failed to restore database status after stop failure: %v", err)
 	}
 	updateDatabaseLocationStatus(ctx, dbInstance.ID, "running")
+}
+
+func (s *Service) persistDatabaseInstance(ctx context.Context, dbInstance *database.DatabaseInstance) error {
+	if s == nil || s.repo == nil {
+		return fmt.Errorf("database repository is unavailable")
+	}
+	return retryDatabaseWrite(ctx, 5, 250*time.Millisecond, func() error {
+		return s.repo.Update(ctx, dbInstance)
+	})
+}
+
+func retryDatabaseWrite(ctx context.Context, attempts int, delay time.Duration, update func() error) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err = update(); err == nil {
+			return nil
+		}
+		if attempt == attempts {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return fmt.Errorf("persist database status: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+	return fmt.Errorf("persist database status after %d attempts: %w", attempts, err)
 }
 
 // Helper function

--- a/apps/databases-service/internal/service/lifecycle.go
+++ b/apps/databases-service/internal/service/lifecycle.go
@@ -299,10 +299,11 @@ func (s *Service) restoreDatabaseAfterFailedStop(ctx context.Context, dbInstance
 		return
 	}
 	dbInstance.Status = 3 // RUNNING: a failed stop must keep proxy, metrics, and uptime tracking active.
-	if err := s.repo.Update(ctx, dbInstance); err != nil {
-		logger.Error("Failed to restore database status after stop failure: %v", err)
+	if err := retryDatabaseWrite(ctx, 5, 250*time.Millisecond, func() error {
+		return database.UpdateDatabaseRuntimeStatus(ctx, dbInstance.ID, 3, "running")
+	}); err != nil {
+		logger.Error("Failed to atomically restore database after stop failure: %v", err)
 	}
-	updateDatabaseLocationStatus(ctx, dbInstance.ID, "running")
 }
 
 func (s *Service) persistDatabaseInstance(ctx context.Context, dbInstance *database.DatabaseInstance) error {

--- a/apps/databases-service/internal/service/lifecycle.go
+++ b/apps/databases-service/internal/service/lifecycle.go
@@ -124,9 +124,7 @@ func (s *Service) StopDatabase(ctx context.Context, req *connect.Request[databas
 		if dbInstance.InstanceID != nil && *dbInstance.InstanceID != "" && s.provisioner != nil {
 			if err := s.provisioner.StopDatabase(stopCtx, *dbInstance.InstanceID); err != nil {
 				logger.Error("Failed to stop database container: %v", err)
-				dbInstance.Status = 8 // FAILED
-				s.repo.Update(stopCtx, dbInstance)
-				updateDatabaseLocationStatus(stopCtx, dbInstance.ID, "failed")
+				s.restoreDatabaseAfterFailedStop(stopCtx, dbInstance)
 				return
 			}
 		}
@@ -256,9 +254,7 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 		if dbInstance.InstanceID != nil && *dbInstance.InstanceID != "" && s.provisioner != nil {
 			if err := s.provisioner.StopDatabase(sleepCtx, *dbInstance.InstanceID); err != nil {
 				logger.Error("Failed to stop database container for sleep: %v", err)
-				dbInstance.Status = 8 // FAILED
-				s.repo.Update(sleepCtx, dbInstance)
-				updateDatabaseLocationStatus(sleepCtx, dbInstance.ID, "failed")
+				s.restoreDatabaseAfterFailedStop(sleepCtx, dbInstance)
 				return
 			}
 		}
@@ -282,6 +278,17 @@ func (s *Service) SleepDatabase(ctx context.Context, req *connect.Request[databa
 		Database: protoDB,
 	})
 	return res, nil
+}
+
+func (s *Service) restoreDatabaseAfterFailedStop(ctx context.Context, dbInstance *database.DatabaseInstance) {
+	if dbInstance == nil {
+		return
+	}
+	dbInstance.Status = 3 // RUNNING: a failed stop must keep proxy, metrics, and uptime tracking active.
+	if err := s.repo.Update(ctx, dbInstance); err != nil {
+		logger.Error("Failed to restore database status after stop failure: %v", err)
+	}
+	updateDatabaseLocationStatus(ctx, dbInstance.ID, "running")
 }
 
 // Helper function

--- a/apps/databases-service/internal/service/lifecycle_tracking_test.go
+++ b/apps/databases-service/internal/service/lifecycle_tracking_test.go
@@ -44,6 +44,41 @@ func TestRetryDatabaseWriteReturnsAfterExhaustion(t *testing.T) {
 	}
 }
 
+func TestPersistDatabaseConnectionIsIdempotent(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:connection-persistence-test?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&database.DatabaseConnection{}); err != nil {
+		t.Fatalf("migrate database connection: %v", err)
+	}
+	service := &Service{connRepo: database.NewDatabaseConnectionRepository(db)}
+	connection := &database.DatabaseConnection{
+		ID:           "conn-persistence-test",
+		DatabaseID:   "db-persistence-test",
+		DatabaseName: "db-persistence-test",
+		Username:     "test-user",
+		Password:     "test-secret",
+		Host:         "db-persistence-test.example.test",
+		Port:         5432,
+	}
+	if err := service.persistDatabaseConnection(t.Context(), connection); err != nil {
+		t.Fatalf("persist database connection: %v", err)
+	}
+	connection.Password = "updated-test-secret"
+	if err := service.persistDatabaseConnection(t.Context(), connection); err != nil {
+		t.Fatalf("repeat database connection persistence: %v", err)
+	}
+
+	var stored []database.DatabaseConnection
+	if err := db.Find(&stored).Error; err != nil {
+		t.Fatalf("load database connections: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Password != connection.Password {
+		t.Fatalf("unexpected persisted connections: %#v", stored)
+	}
+}
+
 func TestRestoreDatabaseAfterFailedStopKeepsTrackingActive(t *testing.T) {
 	previousDB := database.DB
 	db, err := gorm.Open(sqlite.Open("file:failed-stop-tracking-test?mode=memory&cache=shared"), &gorm.Config{})

--- a/apps/databases-service/internal/service/lifecycle_tracking_test.go
+++ b/apps/databases-service/internal/service/lifecycle_tracking_test.go
@@ -1,6 +1,7 @@
 package databases
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -8,6 +9,37 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestRetryDatabaseWriteRetriesTransientFailure(t *testing.T) {
+	attempts := 0
+	err := retryDatabaseWrite(t.Context(), 3, 0, func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("transient write failure")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retry database write: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestRetryDatabaseWriteReturnsAfterExhaustion(t *testing.T) {
+	attempts := 0
+	err := retryDatabaseWrite(t.Context(), 2, 0, func() error {
+		attempts++
+		return errors.New("persistent write failure")
+	})
+	if err == nil {
+		t.Fatal("persistent write failure was ignored")
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
 
 func TestRestoreDatabaseAfterFailedStopKeepsTrackingActive(t *testing.T) {
 	previousDB := database.DB

--- a/apps/databases-service/internal/service/lifecycle_tracking_test.go
+++ b/apps/databases-service/internal/service/lifecycle_tracking_test.go
@@ -79,6 +79,22 @@ func TestPersistDatabaseConnectionIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestFailedUnpublishedDatabaseRetainsOwnerUntilContainerRemoval(t *testing.T) {
+	containerID := "container-cleanup-retry-test"
+	nodeID := "node-cleanup-retry-test"
+	instance := &database.DatabaseInstance{InstanceID: &containerID, NodeID: &nodeID, Status: 3}
+
+	markUnpublishedDatabaseFailed(instance, false)
+	if instance.Status != 8 || instance.InstanceID == nil || *instance.InstanceID != containerID || instance.NodeID == nil || *instance.NodeID != nodeID {
+		t.Fatalf("failed cleanup lost recovery metadata: %#v", instance)
+	}
+
+	markUnpublishedDatabaseFailed(instance, true)
+	if instance.InstanceID != nil || instance.NodeID != nil {
+		t.Fatalf("successful cleanup retained obsolete ownership metadata: %#v", instance)
+	}
+}
+
 func TestRestoreDatabaseAfterFailedStopKeepsTrackingActive(t *testing.T) {
 	previousDB := database.DB
 	db, err := gorm.Open(sqlite.Open("file:failed-stop-tracking-test?mode=memory&cache=shared"), &gorm.Config{})
@@ -169,7 +185,7 @@ func TestRestoreContainerAfterAutoSleepFailureRestartsRunningRoute(t *testing.T)
 			return nil
 		},
 	}
-	if err := service.restoreContainerAfterAutoSleepFailure(route); err != nil {
+	if err := service.restoreContainerAfterSleepingWriteFailure(route); err != nil {
 		t.Fatalf("restore stopped database container: %v", err)
 	}
 	if startedContainerID != route.ContainerID {
@@ -201,7 +217,7 @@ func TestRestoreContainerAfterAutoSleepFailureRetainsSleepingRouteWhenRestartFai
 			return errors.New("restart failed")
 		},
 	}
-	if err := service.restoreContainerAfterAutoSleepFailure(route); err == nil {
+	if err := service.restoreContainerAfterSleepingWriteFailure(route); err == nil {
 		t.Fatal("expected the failed container restart to be reported")
 	}
 	storedRoute, ok := registry.LookupByID(route.DatabaseID)

--- a/apps/databases-service/internal/service/lifecycle_tracking_test.go
+++ b/apps/databases-service/internal/service/lifecycle_tracking_test.go
@@ -1,9 +1,12 @@
 package databases
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
+
+	"databases-service/internal/proxy"
 
 	"github.com/obiente/cloud/apps/shared/pkg/database"
 	"gorm.io/driver/sqlite"
@@ -109,5 +112,68 @@ func TestRestoreDatabaseAfterFailedStopKeepsTrackingActive(t *testing.T) {
 	}
 	if openIntervals != 1 {
 		t.Fatalf("expected one open uptime interval, got %d", openIntervals)
+	}
+}
+
+func TestRestoreContainerAfterAutoSleepFailureRestartsRunningRoute(t *testing.T) {
+	registry := proxy.NewRouteRegistry(nil)
+	route := &proxy.Route{
+		DatabaseID:  "db-auto-sleep-rollback-test",
+		ContainerID: "container-auto-sleep-rollback-test",
+		ContainerIP: "obiente-db-auto-sleep-rollback-test",
+		DBStatus:    3,
+	}
+	registry.Register(route)
+
+	startedContainerID := ""
+	service := &Service{
+		backgroundCtx: t.Context(),
+		routeRegistry: registry,
+		startStoppedDB: func(_ context.Context, containerID string) error {
+			startedContainerID = containerID
+			return nil
+		},
+	}
+	if err := service.restoreContainerAfterAutoSleepFailure(route); err != nil {
+		t.Fatalf("restore stopped database container: %v", err)
+	}
+	if startedContainerID != route.ContainerID {
+		t.Fatalf("started container %q, want %q", startedContainerID, route.ContainerID)
+	}
+	storedRoute, ok := registry.LookupByID(route.DatabaseID)
+	if !ok {
+		t.Fatal("restored route is missing")
+	}
+	if storedRoute.Stopped || storedRoute.DBStatus != 3 {
+		t.Fatalf("expected running route after rollback, got %#v", storedRoute)
+	}
+}
+
+func TestRestoreContainerAfterAutoSleepFailureRetainsSleepingRouteWhenRestartFails(t *testing.T) {
+	registry := proxy.NewRouteRegistry(nil)
+	route := &proxy.Route{
+		DatabaseID:  "db-auto-sleep-retry-test",
+		ContainerID: "container-auto-sleep-retry-test",
+		ContainerIP: "obiente-db-auto-sleep-retry-test",
+		DBStatus:    3,
+	}
+	registry.Register(route)
+
+	service := &Service{
+		backgroundCtx: t.Context(),
+		routeRegistry: registry,
+		startStoppedDB: func(context.Context, string) error {
+			return errors.New("restart failed")
+		},
+	}
+	if err := service.restoreContainerAfterAutoSleepFailure(route); err == nil {
+		t.Fatal("expected the failed container restart to be reported")
+	}
+	storedRoute, ok := registry.LookupByID(route.DatabaseID)
+	if !ok {
+		t.Fatal("sleeping route is missing")
+	}
+	if !storedRoute.Stopped || storedRoute.DBStatus != 12 {
+		t.Fatalf("expected sleeping route after failed rollback, got %#v", storedRoute)
 	}
 }

--- a/apps/databases-service/internal/service/lifecycle_tracking_test.go
+++ b/apps/databases-service/internal/service/lifecycle_tracking_test.go
@@ -1,0 +1,81 @@
+package databases
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obiente/cloud/apps/shared/pkg/database"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRestoreDatabaseAfterFailedStopKeepsTrackingActive(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:failed-stop-tracking-test?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(
+		&database.DatabaseInstance{},
+		&database.DatabaseLocation{},
+		&database.DatabaseUptimeInterval{},
+	); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	databaseID := "db-failed-stop-tracking-test"
+	containerID := "container-failed-stop-tracking-test"
+	instance := &database.DatabaseInstance{ID: databaseID, InstanceID: &containerID, Status: 4}
+	if err := db.Create(instance).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := db.Create(&database.DatabaseLocation{
+		ID:          database.DatabaseLocationID(databaseID, containerID),
+		DatabaseID:  databaseID,
+		NodeID:      "node-failed-stop-tracking-test",
+		ContainerID: containerID,
+		Status:      "stopping",
+	}).Error; err != nil {
+		t.Fatalf("create database location: %v", err)
+	}
+	endedAt := time.Now().Add(-time.Minute)
+	if err := db.Create(&database.DatabaseUptimeInterval{
+		ID:          "interval-before-failed-stop",
+		DatabaseID:  databaseID,
+		ContainerID: containerID,
+		NodeID:      "node-failed-stop-tracking-test",
+		StartedAt:   endedAt.Add(-time.Hour),
+		EndedAt:     &endedAt,
+	}).Error; err != nil {
+		t.Fatalf("create closed uptime interval: %v", err)
+	}
+
+	service := &Service{repo: database.NewDatabaseRepository(db, nil)}
+	service.restoreDatabaseAfterFailedStop(t.Context(), instance)
+
+	var storedInstance database.DatabaseInstance
+	if err := db.First(&storedInstance, "id = ?", databaseID).Error; err != nil {
+		t.Fatalf("load database instance: %v", err)
+	}
+	if storedInstance.Status != 3 {
+		t.Fatalf("expected running database status, got %d", storedInstance.Status)
+	}
+	var storedLocation database.DatabaseLocation
+	if err := db.First(&storedLocation, "container_id = ?", containerID).Error; err != nil {
+		t.Fatalf("load database location: %v", err)
+	}
+	if storedLocation.Status != "running" {
+		t.Fatalf("expected running location status, got %q", storedLocation.Status)
+	}
+	var openIntervals int64
+	if err := db.Model(&database.DatabaseUptimeInterval{}).
+		Where("database_id = ? AND container_id = ? AND ended_at IS NULL", databaseID, containerID).
+		Count(&openIntervals).Error; err != nil {
+		t.Fatalf("count open uptime intervals: %v", err)
+	}
+	if openIntervals != 1 {
+		t.Fatalf("expected one open uptime interval, got %d", openIntervals)
+	}
+}

--- a/apps/databases-service/internal/service/service.go
+++ b/apps/databases-service/internal/service/service.go
@@ -100,9 +100,11 @@ func (s *Service) wakeDatabase(ctx context.Context, route *proxy.Route) (string,
 	}
 
 	logger.Info("Waking database %s", route.DatabaseID)
+	updateDatabaseLocationStatus(ctx, route.DatabaseID, "starting")
 
 	// Start the container
 	if err := s.provisioner.StartDatabase(ctx, route.ContainerID); err != nil {
+		updateDatabaseLocationStatus(ctx, route.DatabaseID, "failed")
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
 
@@ -119,6 +121,7 @@ func (s *Service) wakeDatabase(ctx context.Context, route *proxy.Route) (string,
 		dbInstance.LastStartedAt = timePtr(time.Now())
 		s.repo.Update(ctx, dbInstance)
 	}
+	updateDatabaseLocationStatus(ctx, route.DatabaseID, "running")
 
 	// Update route
 	s.routeRegistry.MarkRunning(route.DatabaseID, ip)
@@ -152,9 +155,11 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 	}
 
 	logger.Info("Auto-sleeping database %s due to inactivity", route.DatabaseID)
+	updateDatabaseLocationStatus(ctx, route.DatabaseID, "stopping")
 
 	// Stop the container
 	if err := s.provisioner.StopDatabase(ctx, route.ContainerID); err != nil {
+		updateDatabaseLocationStatus(ctx, route.DatabaseID, "running")
 		return fmt.Errorf("failed to stop container: %w", err)
 	}
 
@@ -164,6 +169,7 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 		dbInstance.Status = 12 // SLEEPING
 		s.repo.Update(ctx, dbInstance)
 	}
+	updateDatabaseLocationStatus(ctx, route.DatabaseID, "sleeping")
 
 	// Update route
 	s.routeRegistry.MarkStopped(route.DatabaseID, 12)

--- a/apps/databases-service/internal/service/service.go
+++ b/apps/databases-service/internal/service/service.go
@@ -34,6 +34,7 @@ type Service struct {
 	routeRegistry     *proxy.RouteRegistry
 	backgroundCtx     context.Context
 	proxyEnabled      bool
+	startStoppedDB    func(context.Context, string) error
 }
 
 func NewService(
@@ -75,6 +76,9 @@ func NewService(
 		routeRegistry:     registry,
 		backgroundCtx:     backgroundCtx,
 		proxyEnabled:      true,
+	}
+	if prov != nil {
+		svc.startStoppedDB = prov.StartDatabase
 	}
 
 	// Wire wake/sleep callbacks
@@ -179,7 +183,14 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 	}
 	dbInstance.Status = 12 // SLEEPING
 	if err := s.persistDatabaseInstance(ctx, dbInstance); err != nil {
-		return fmt.Errorf("persist sleeping database status: %w", err)
+		persistErr := err
+		dbInstance.Status = 3 // The durable status is still RUNNING when every write failed.
+		if restoreErr := s.restoreContainerAfterAutoSleepFailure(route); restoreErr != nil {
+			updateDatabaseLocationStatus(ctx, route.DatabaseID, "sleeping")
+			return fmt.Errorf("persist sleeping database status: %v; restore stopped database container: %w", persistErr, restoreErr)
+		}
+		updateDatabaseLocationStatus(ctx, route.DatabaseID, "running")
+		return fmt.Errorf("persist sleeping database status; restored database container to match durable RUNNING state: %w", persistErr)
 	}
 	updateDatabaseLocationStatus(ctx, route.DatabaseID, "sleeping")
 
@@ -209,6 +220,28 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 	}()
 
 	logger.Info("Database %s put to sleep", route.DatabaseID)
+	return nil
+}
+
+func (s *Service) restoreContainerAfterAutoSleepFailure(route *proxy.Route) error {
+	if s == nil || route == nil || route.ContainerID == "" || s.startStoppedDB == nil {
+		if s != nil && s.routeRegistry != nil && route != nil {
+			s.routeRegistry.MarkStopped(route.DatabaseID, 12)
+		}
+		return fmt.Errorf("database container restore is unavailable")
+	}
+
+	restoreCtx, cancel := s.detachedContext(time.Minute)
+	defer cancel()
+	if err := s.startStoppedDB(restoreCtx, route.ContainerID); err != nil {
+		if s.routeRegistry != nil {
+			s.routeRegistry.MarkStopped(route.DatabaseID, 12)
+		}
+		return err
+	}
+	if s.routeRegistry != nil {
+		s.routeRegistry.MarkRunning(route.DatabaseID, fmt.Sprintf("obiente-%s", route.DatabaseID))
+	}
 	return nil
 }
 

--- a/apps/databases-service/internal/service/service.go
+++ b/apps/databases-service/internal/service/service.go
@@ -183,14 +183,7 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 	}
 	dbInstance.Status = 12 // SLEEPING
 	if err := s.persistDatabaseInstance(ctx, dbInstance); err != nil {
-		persistErr := err
-		dbInstance.Status = 3 // The durable status is still RUNNING when every write failed.
-		if restoreErr := s.restoreContainerAfterAutoSleepFailure(route); restoreErr != nil {
-			updateDatabaseLocationStatus(ctx, route.DatabaseID, "sleeping")
-			return fmt.Errorf("persist sleeping database status: %v; restore stopped database container: %w", persistErr, restoreErr)
-		}
-		updateDatabaseLocationStatus(ctx, route.DatabaseID, "running")
-		return fmt.Errorf("persist sleeping database status; restored database container to match durable RUNNING state: %w", persistErr)
+		return s.recoverAfterSleepingWriteFailure(dbInstance, route, err)
 	}
 	updateDatabaseLocationStatus(ctx, route.DatabaseID, "sleeping")
 
@@ -223,7 +216,50 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 	return nil
 }
 
-func (s *Service) restoreContainerAfterAutoSleepFailure(route *proxy.Route) error {
+func (s *Service) recoverAfterSleepingWriteFailure(instance *database.DatabaseInstance, route *proxy.Route, persistErr error) error {
+	if route == nil {
+		return fmt.Errorf("persist sleeping database status: %w", persistErr)
+	}
+	rollbackCtx, rollbackCancel := s.detachedContext(30 * time.Second)
+	defer rollbackCancel()
+	if instance != nil {
+		instance.Status = 3 // The durable state remains RUNNING until SLEEPING commits.
+	}
+	if restoreErr := s.restoreContainerAfterSleepingWriteFailure(route); restoreErr != nil {
+		if instance != nil {
+			s.retrySleepingIntent(instance, route)
+		}
+		updateDatabaseLocationStatus(rollbackCtx, route.DatabaseID, "sleeping")
+		return fmt.Errorf("persist sleeping database status: %v; restore stopped database container: %w", persistErr, restoreErr)
+	}
+	updateDatabaseLocationStatus(rollbackCtx, route.DatabaseID, "running")
+	return fmt.Errorf("persist sleeping database status; restored database container to match durable RUNNING state: %w", persistErr)
+}
+
+func (s *Service) retrySleepingIntent(instance *database.DatabaseInstance, route *proxy.Route) {
+	if s == nil || s.repo == nil || instance == nil {
+		return
+	}
+	retryInstance := *instance
+	retryInstance.Status = 12
+	go func() {
+		retryCtx, cancel := s.detachedContext(2 * time.Minute)
+		defer cancel()
+		err := retryDatabaseWrite(retryCtx, 24, 5*time.Second, func() error {
+			return s.repo.Update(retryCtx, &retryInstance)
+		})
+		if err != nil {
+			logger.Error("Failed to retain sleeping intent for database %s: %v", retryInstance.ID, err)
+			return
+		}
+		updateDatabaseLocationStatus(retryCtx, retryInstance.ID, "sleeping")
+		if s.routeRegistry != nil && route != nil {
+			s.routeRegistry.MarkStopped(retryInstance.ID, 12)
+		}
+	}()
+}
+
+func (s *Service) restoreContainerAfterSleepingWriteFailure(route *proxy.Route) error {
 	if s == nil || route == nil || route.ContainerID == "" || s.startStoppedDB == nil {
 		if s != nil && s.routeRegistry != nil && route != nil {
 			s.routeRegistry.MarkStopped(route.DatabaseID, 12)

--- a/apps/databases-service/internal/service/service.go
+++ b/apps/databases-service/internal/service/service.go
@@ -33,6 +33,7 @@ type Service struct {
 	proxy             *proxy.Proxy
 	routeRegistry     *proxy.RouteRegistry
 	backgroundCtx     context.Context
+	proxyEnabled      bool
 }
 
 func NewService(
@@ -73,6 +74,7 @@ func NewService(
 		proxy:             proxyServer,
 		routeRegistry:     registry,
 		backgroundCtx:     backgroundCtx,
+		proxyEnabled:      true,
 	}
 
 	// Wire wake/sleep callbacks
@@ -80,6 +82,10 @@ func NewService(
 	registry.OnSleep = svc.sleepDatabaseAuto
 
 	return svc
+}
+
+func (s *Service) SetProxyEnabled(enabled bool) {
+	s.proxyEnabled = enabled
 }
 
 func (s *Service) detachedContext(timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/apps/databases-service/internal/service/service.go
+++ b/apps/databases-service/internal/service/service.go
@@ -116,10 +116,13 @@ func (s *Service) wakeDatabase(ctx context.Context, route *proxy.Route) (string,
 
 	// Update DB status to RUNNING
 	dbInstance, err := s.repo.GetByID(ctx, route.DatabaseID)
-	if err == nil {
-		dbInstance.Status = 3 // RUNNING
-		dbInstance.LastStartedAt = timePtr(time.Now())
-		s.repo.Update(ctx, dbInstance)
+	if err != nil {
+		return "", fmt.Errorf("load database before publishing running status: %w", err)
+	}
+	dbInstance.Status = 3 // RUNNING
+	dbInstance.LastStartedAt = timePtr(time.Now())
+	if err := s.persistDatabaseInstance(ctx, dbInstance); err != nil {
+		return "", fmt.Errorf("persist running database status: %w", err)
 	}
 	updateDatabaseLocationStatus(ctx, route.DatabaseID, "running")
 
@@ -165,9 +168,12 @@ func (s *Service) sleepDatabaseAuto(ctx context.Context, route *proxy.Route) err
 
 	// Update DB status to SLEEPING
 	dbInstance, err := s.repo.GetByID(ctx, route.DatabaseID)
-	if err == nil {
-		dbInstance.Status = 12 // SLEEPING
-		s.repo.Update(ctx, dbInstance)
+	if err != nil {
+		return fmt.Errorf("load database before publishing sleeping status: %w", err)
+	}
+	dbInstance.Status = 12 // SLEEPING
+	if err := s.persistDatabaseInstance(ctx, dbInstance); err != nil {
+		return fmt.Errorf("persist sleeping database status: %w", err)
 	}
 	updateDatabaseLocationStatus(ctx, route.DatabaseID, "sleeping")
 

--- a/apps/databases-service/internal/service/usage.go
+++ b/apps/databases-service/internal/service/usage.go
@@ -76,40 +76,17 @@ func (s *Service) GetDatabaseUsage(ctx context.Context, req *connect.Request[dat
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to calculate usage: %w", err))
 	}
 
-	// Calculate uptime from database_locations
-	var uptime struct {
-		UptimeSeconds int64
+	// Sum only the portions of running intervals that overlap the requested
+	// month. This excludes stopped time and clamps long-running databases to the
+	// month boundary.
+	requestedMonthEnd := requestedMonthStart.AddDate(0, 1, 0)
+	var uptimeIntervals []database.DatabaseUptimeInterval
+	if err := database.DB.WithContext(ctx).
+		Where("database_id = ? AND started_at < ? AND (ended_at IS NULL OR ended_at > ?)", databaseID, requestedMonthEnd, requestedMonthStart).
+		Find(&uptimeIntervals).Error; err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to calculate database uptime: %w", err))
 	}
-	if month == now.Format("2006-01") {
-		database.DB.Table("database_locations dl").
-			Select(`
-				COALESCE(SUM(EXTRACT(EPOCH FROM (
-					CASE
-						WHEN dl.status = 'running' THEN NOW() - dl.created_at
-						WHEN dl.updated_at > dl.created_at THEN dl.updated_at - dl.created_at
-						ELSE '0 seconds'::interval
-					END
-				))), 0)::bigint as uptime_seconds
-			`).
-			Where("dl.database_id = ? AND (dl.created_at >= ? OR dl.updated_at >= ?)", databaseID, monthStart, monthStart).
-			Scan(&uptime)
-	} else {
-		database.DB.Table("database_locations dl").
-			Select(`
-				COALESCE(SUM(EXTRACT(EPOCH FROM (
-					CASE
-						WHEN dl.status = 'running' AND dl.updated_at <= ? THEN ?::timestamp - dl.created_at
-						WHEN dl.updated_at > dl.created_at AND dl.updated_at <= ? THEN dl.updated_at - dl.created_at
-						WHEN dl.created_at >= ? AND dl.created_at < ? THEN ?::timestamp - dl.created_at
-						ELSE '0 seconds'::interval
-					END
-				))), 0)::bigint as uptime_seconds
-			`, monthEnd, monthEnd, monthEnd, requestedMonthStart, monthEnd, monthEnd).
-			Where("dl.database_id = ? AND ((dl.created_at >= ? AND dl.created_at <= ?) OR (dl.updated_at >= ? AND dl.updated_at <= ?))",
-				databaseID, requestedMonthStart, monthEnd, requestedMonthStart, monthEnd).
-			Scan(&uptime)
-	}
-	currentMetrics.UptimeSeconds = uptime.UptimeSeconds
+	currentMetrics.UptimeSeconds = databaseUptimeSeconds(uptimeIntervals, requestedMonthStart, requestedMonthEnd, now)
 
 	// Calculate estimated monthly usage
 	var estimatedMonthly common.ContainerUsageMetrics
@@ -126,12 +103,12 @@ func (s *Service) GetDatabaseUsage(ctx context.Context, req *connect.Request[dat
 
 	// Build response
 	currentProto := &databasesv1.DatabaseUsageMetrics{
-		CpuCoreSeconds:    currentMetrics.CPUCoreSeconds,
-		MemoryByteSeconds: currentMetrics.MemoryByteSeconds,
-		BandwidthRxBytes:  currentMetrics.BandwidthRxBytes,
-		BandwidthTxBytes:  currentMetrics.BandwidthTxBytes,
-		StorageBytes:      currentMetrics.StorageBytes,
-		UptimeSeconds:     currentMetrics.UptimeSeconds,
+		CpuCoreSeconds:     currentMetrics.CPUCoreSeconds,
+		MemoryByteSeconds:  currentMetrics.MemoryByteSeconds,
+		BandwidthRxBytes:   currentMetrics.BandwidthRxBytes,
+		BandwidthTxBytes:   currentMetrics.BandwidthTxBytes,
+		StorageBytes:       currentMetrics.StorageBytes,
+		UptimeSeconds:      currentMetrics.UptimeSeconds,
 		EstimatedCostCents: currTotalCost,
 	}
 	currCPUCostPtr := int64(currCPUCost)
@@ -144,12 +121,12 @@ func (s *Service) GetDatabaseUsage(ctx context.Context, req *connect.Request[dat
 	currentProto.StorageCostCents = &currStorageCostPtr
 
 	estimatedProto := &databasesv1.DatabaseUsageMetrics{
-		CpuCoreSeconds:    estimatedMonthly.CPUCoreSeconds,
-		MemoryByteSeconds: estimatedMonthly.MemoryByteSeconds,
-		BandwidthRxBytes:  estimatedMonthly.BandwidthRxBytes,
-		BandwidthTxBytes:  estimatedMonthly.BandwidthTxBytes,
-		StorageBytes:      estimatedMonthly.StorageBytes,
-		UptimeSeconds:     estimatedMonthly.UptimeSeconds,
+		CpuCoreSeconds:     estimatedMonthly.CPUCoreSeconds,
+		MemoryByteSeconds:  estimatedMonthly.MemoryByteSeconds,
+		BandwidthRxBytes:   estimatedMonthly.BandwidthRxBytes,
+		BandwidthTxBytes:   estimatedMonthly.BandwidthTxBytes,
+		StorageBytes:       estimatedMonthly.StorageBytes,
+		UptimeSeconds:      estimatedMonthly.UptimeSeconds,
 		EstimatedCostCents: estTotalCost,
 	}
 	estCPUCostPtr := int64(estCPUCost)
@@ -170,4 +147,25 @@ func (s *Service) GetDatabaseUsage(ctx context.Context, req *connect.Request[dat
 	}
 
 	return connect.NewResponse(response), nil
+}
+
+func databaseUptimeSeconds(intervals []database.DatabaseUptimeInterval, periodStart, periodEnd, now time.Time) int64 {
+	var uptime time.Duration
+	for _, interval := range intervals {
+		start := interval.StartedAt
+		if start.Before(periodStart) {
+			start = periodStart
+		}
+		end := now
+		if interval.EndedAt != nil {
+			end = *interval.EndedAt
+		}
+		if end.After(periodEnd) {
+			end = periodEnd
+		}
+		if end.After(start) {
+			uptime += end.Sub(start)
+		}
+	}
+	return int64(uptime / time.Second)
 }

--- a/apps/databases-service/internal/service/usage_test.go
+++ b/apps/databases-service/internal/service/usage_test.go
@@ -1,0 +1,42 @@
+package databases
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obiente/cloud/apps/shared/pkg/database"
+)
+
+func TestDatabaseUptimeSecondsClampsIntervalsAndExcludesDowntime(t *testing.T) {
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	beforePeriod := periodStart.Add(-24 * time.Hour)
+	firstStop := periodStart.Add(48 * time.Hour)
+	restart := periodStart.Add(72 * time.Hour)
+	afterPeriod := periodEnd.Add(24 * time.Hour)
+
+	intervals := []database.DatabaseUptimeInterval{
+		{StartedAt: beforePeriod, EndedAt: &firstStop},
+		{StartedAt: restart},
+		{StartedAt: periodEnd.Add(time.Hour), EndedAt: &afterPeriod},
+	}
+
+	want := int64((48*time.Hour + now.Sub(restart)) / time.Second)
+	if got := databaseUptimeSeconds(intervals, periodStart, periodEnd, now); got != want {
+		t.Fatalf("databaseUptimeSeconds() = %d, want %d", got, want)
+	}
+}
+
+func TestDatabaseUptimeSecondsClampsHistoricalIntervalToMonth(t *testing.T) {
+	periodStart := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+	startedBefore := periodStart.AddDate(0, -1, 0)
+	endedAfter := periodEnd.AddDate(0, 1, 0)
+
+	intervals := []database.DatabaseUptimeInterval{{StartedAt: startedBefore, EndedAt: &endedAfter}}
+	want := int64(periodEnd.Sub(periodStart) / time.Second)
+	if got := databaseUptimeSeconds(intervals, periodStart, periodEnd, periodEnd); got != want {
+		t.Fatalf("databaseUptimeSeconds() = %d, want %d", got, want)
+	}
+}

--- a/apps/databases-service/main.go
+++ b/apps/databases-service/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -35,6 +36,22 @@ const (
 	gracefulShutdownMessage = "shutting down server"
 )
 
+type serviceMode struct {
+	controlPlane bool
+	proxy        bool
+}
+
+func parseServiceMode(value string) serviceMode {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "control-plane":
+		return serviceMode{controlPlane: true}
+	case "proxy":
+		return serviceMode{proxy: true}
+	default:
+		return serviceMode{controlPlane: true, proxy: true}
+	}
+}
+
 func main() {
 	// Set log output and flags
 	log.SetOutput(os.Stdout)
@@ -45,6 +62,7 @@ func main() {
 
 	logger.Info("=== Databases Service Starting ===")
 	logger.Debug("LOG_LEVEL: %s", os.Getenv("LOG_LEVEL"))
+	mode := parseServiceMode(os.Getenv("DATABASES_SERVICE_MODE"))
 
 	database.RegisterModels(
 		&database.DatabaseInstance{},
@@ -90,39 +108,47 @@ func main() {
 	backupRepo := database.NewDatabaseBackupRepository(database.DB)
 	databaseService := databasessvc.NewService(shutdownCtx, databaseRepo, connRepo, backupRepo)
 
-	// Register databases service
-	databasesPath, databasesHandler := databasesv1connect.NewDatabaseServiceHandler(
-		databaseService,
-		connect.WithInterceptors(auditInterceptor, authInterceptor),
-	)
-	mux.Handle(databasesPath, databasesHandler)
+	if mode.controlPlane {
+		// Register the control-plane RPCs only on the node-local owner task.
+		databasesPath, databasesHandler := databasesv1connect.NewDatabaseServiceHandler(
+			databaseService,
+			connect.WithInterceptors(auditInterceptor, authInterceptor),
+		)
+		mux.Handle(databasesPath, databasesHandler)
+	}
 
 	// Load existing routes and start proxy
 	proxyServer := databaseService.GetProxy()
 	routeRegistry := databaseService.GetRouteRegistry()
 
-	loadCtx, loadCancel := context.WithTimeout(shutdownCtx, 30*time.Second)
-	if err := routeRegistry.LoadFromDatabase(loadCtx); err != nil {
-		logger.Warn("Failed to load routes from database: %v", err)
-	} else {
-		logger.Info("✓ Routes loaded from database (%d routes)", routeRegistry.RouteCount())
-	}
-	loadCancel()
-
-	// Start proxy in background
 	proxyErr := make(chan error, 1)
-	go func() {
-		if err := proxyServer.Start(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {
-			proxyErr <- err
+	if mode.proxy {
+		loadCtx, loadCancel := context.WithTimeout(shutdownCtx, 30*time.Second)
+		if err := routeRegistry.LoadFromDatabase(loadCtx); err != nil {
+			logger.Warn("Failed to load routes from database: %v", err)
+		} else {
+			logger.Info("✓ Routes loaded from database (%d routes)", routeRegistry.RouteCount())
 		}
-	}()
-	logger.Info("✓ Database proxy starting")
+		loadCancel()
+
+		// Start proxy in background
+		go func() {
+			if err := proxyServer.Start(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {
+				proxyErr <- err
+			}
+		}()
+		logger.Info("✓ Database proxy starting")
+	}
 
 	// Health check endpoint
 	mux.HandleFunc("/health", health.HandleHealth("databases-service", func() (bool, string, map[string]interface{}) {
 		extra := map[string]interface{}{
-			"proxy_running": proxyServer.Healthy(),
-			"routes":        routeRegistry.RouteCount(),
+			"control_plane": mode.controlPlane,
+			"proxy_enabled": mode.proxy,
+		}
+		if mode.proxy {
+			extra["proxy_running"] = proxyServer.Healthy()
+			extra["routes"] = routeRegistry.RouteCount()
 		}
 
 		databaseReachable := false
@@ -136,28 +162,30 @@ func main() {
 		}
 		extra["database_reachable"] = databaseReachable
 
-		if !proxyServer.Healthy() {
+		if mode.proxy && !proxyServer.Healthy() {
 			return false, "proxy unavailable", extra
 		}
 
-		// Keep liveness healthy while the proxy is running, even if metadata DB is transiently unavailable.
+		// Keep liveness healthy while the selected role is running, even if metadata DB is transiently unavailable.
 		if !databaseReachable {
-			return true, "proxy healthy (database degraded)", extra
+			return true, "service healthy (database degraded)", extra
 		}
 
 		return true, "healthy", extra
 	}))
 
-	// Proxy health endpoint
-	mux.HandleFunc("/health/proxy", func(w http.ResponseWriter, r *http.Request) {
-		if proxyServer.Healthy() {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"status":"healthy","routes":` + fmt.Sprintf("%d", routeRegistry.RouteCount()) + `}`))
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte(`{"status":"unhealthy"}`))
-		}
-	})
+	if mode.proxy {
+		// Proxy health endpoint
+		mux.HandleFunc("/health/proxy", func(w http.ResponseWriter, r *http.Request) {
+			if proxyServer.Healthy() {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status":"healthy","routes":` + fmt.Sprintf("%d", routeRegistry.RouteCount()) + `}`))
+			} else {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte(`{"status":"unhealthy"}`))
+			}
+		})
+	}
 
 	// Root endpoint
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -207,9 +235,11 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 
-		// Stop proxy first
-		proxyServer.Stop()
-		logger.Info("✓ Proxy stopped")
+		if mode.proxy {
+			// Stop proxy first
+			proxyServer.Stop()
+			logger.Info("✓ Proxy stopped")
+		}
 
 		if err := httpServer.Shutdown(ctx); err != nil {
 			logger.Warn("Error during server shutdown: %v", err)

--- a/apps/databases-service/main.go
+++ b/apps/databases-service/main.go
@@ -142,6 +142,9 @@ func main() {
 			}
 		}()
 		logger.Info("✓ Database proxy starting")
+	} else if mode.controlPlane {
+		routeRegistry.StartDatabaseSync(shutdownCtx, 10*time.Second)
+		logger.Info("✓ Database control-plane route refresh started")
 	}
 
 	// Health check endpoint

--- a/apps/databases-service/main.go
+++ b/apps/databases-service/main.go
@@ -107,6 +107,7 @@ func main() {
 	connRepo := database.NewDatabaseConnectionRepository(database.DB)
 	backupRepo := database.NewDatabaseBackupRepository(database.DB)
 	databaseService := databasessvc.NewService(shutdownCtx, databaseRepo, connRepo, backupRepo)
+	databaseService.SetProxyEnabled(mode.proxy)
 
 	if mode.controlPlane {
 		// Register the control-plane RPCs only on the node-local owner task.
@@ -120,6 +121,7 @@ func main() {
 	// Load existing routes and start proxy
 	proxyServer := databaseService.GetProxy()
 	routeRegistry := databaseService.GetRouteRegistry()
+	routeRegistry.SetLocalRoutesOnly(mode.proxy && !mode.controlPlane)
 
 	proxyErr := make(chan error, 1)
 	if mode.controlPlane || mode.proxy {

--- a/apps/databases-service/main.go
+++ b/apps/databases-service/main.go
@@ -122,7 +122,7 @@ func main() {
 	routeRegistry := databaseService.GetRouteRegistry()
 
 	proxyErr := make(chan error, 1)
-	if mode.proxy {
+	if mode.controlPlane || mode.proxy {
 		loadCtx, loadCancel := context.WithTimeout(shutdownCtx, 30*time.Second)
 		if err := routeRegistry.LoadFromDatabase(loadCtx); err != nil {
 			logger.Warn("Failed to load routes from database: %v", err)
@@ -130,7 +130,9 @@ func main() {
 			logger.Info("✓ Routes loaded from database (%d routes)", routeRegistry.RouteCount())
 		}
 		loadCancel()
+	}
 
+	if mode.proxy {
 		// Start proxy in background
 		go func() {
 			if err := proxyServer.Start(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {

--- a/apps/databases-service/main_test.go
+++ b/apps/databases-service/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestParseServiceMode(t *testing.T) {
+	tests := map[string]serviceMode{
+		"":              {controlPlane: true, proxy: true},
+		"all":           {controlPlane: true, proxy: true},
+		"control-plane": {controlPlane: true},
+		"proxy":         {proxy: true},
+		" PROXY ":       {proxy: true},
+	}
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			if got := parseServiceMode(input); got != want {
+				t.Fatalf("parseServiceMode(%q) = %#v, want %#v", input, got, want)
+			}
+		})
+	}
+}

--- a/apps/dns-service/main.go
+++ b/apps/dns-service/main.go
@@ -1281,7 +1281,7 @@ func pushDNSRecords(ctx context.Context, client *http.Client, pushURL, apiKey, s
 		Scan(&databaseRows).Error; err != nil {
 		log.Printf("[DNS Pusher] Failed to query databases: %v", err)
 	} else {
-		records = append(records, collectDatabaseDNSRecords(databaseRows, nodeIPMap, ttl)...)
+		records = append(records, collectDatabaseDNSRecords(databaseRows, nodeIPMap, ttl, database.GetDatabaseNodeIP)...)
 	}
 
 	// Get all running game servers
@@ -1488,10 +1488,15 @@ func pushDNSRecords(ctx context.Context, client *http.Client, pushURL, apiKey, s
 	}
 }
 
-func collectDatabaseDNSRecords(rows []databaseDNSRow, nodeIPMap map[string][]string, ttl int64) []map[string]interface{} {
+func collectDatabaseDNSRecords(
+	rows []databaseDNSRow,
+	nodeIPMap map[string][]string,
+	ttl int64,
+	resolveNodeIPs func(string, map[string][]string) ([]string, error),
+) []map[string]interface{} {
 	records := make([]map[string]interface{}, 0, len(rows)*2)
 	for _, row := range rows {
-		ips, err := database.GetDatabaseNodeIP(row.DatabaseID, nodeIPMap)
+		ips, err := resolveNodeIPs(row.DatabaseID, nodeIPMap)
 		if err != nil {
 			log.Printf("[DNS Pusher] Skipping database %s because its host node could not be resolved: %v", row.DatabaseID, err)
 			continue

--- a/apps/dns-service/main.go
+++ b/apps/dns-service/main.go
@@ -1184,6 +1184,11 @@ func startDNSPusher(ctx context.Context, productionAPIURL, apiKey, sourceAPI str
 	}
 }
 
+type databaseDNSRow struct {
+	DatabaseID   string
+	DatabaseType string
+}
+
 // pushDNSRecords collects all DNS records and pushes them to the production API
 func pushDNSRecords(ctx context.Context, client *http.Client, pushURL, apiKey, sourceAPI string, ttl int64, nodeIPMap map[string][]string) {
 	records := make([]map[string]interface{}, 0)
@@ -1269,10 +1274,6 @@ func pushDNSRecords(ctx context.Context, client *http.Client, pushURL, apiKey, s
 	}
 
 	// Get all provisioned databases and push their DNS records
-	type databaseDNSRow struct {
-		DatabaseID   string
-		DatabaseType string
-	}
 	var databaseRows []databaseDNSRow
 	if err := database.DB.Table("database_instances").
 		Select("id as database_id, type as database_type").
@@ -1280,51 +1281,7 @@ func pushDNSRecords(ctx context.Context, client *http.Client, pushURL, apiKey, s
 		Scan(&databaseRows).Error; err != nil {
 		log.Printf("[DNS Pusher] Failed to query databases: %v", err)
 	} else {
-		// Process each database
-		for _, row := range databaseRows {
-			// Get node IPs for databases (use default region)
-			// Databases are accessed via Traefik on standard ports, so use Traefik IPs
-			var ips []string
-			if defaultIPs, ok := nodeIPMap["default"]; ok && len(defaultIPs) > 0 {
-				ips = defaultIPs
-			} else {
-				// Fallback: get first available IPs from any region
-				for _, regionIPs := range nodeIPMap {
-					if len(regionIPs) > 0 {
-						ips = regionIPs
-						break
-					}
-				}
-			}
-
-			if resolvedIPs, err := database.GetDatabaseNodeIP(row.DatabaseID, nodeIPMap); err == nil && len(resolvedIPs) > 0 {
-				ips = resolvedIPs
-			}
-
-			if len(ips) > 0 {
-				canonicalDomain := database.DefaultMyObienteCloudDomain(row.DatabaseID)
-				records = append(records, map[string]interface{}{
-					"domain":      canonicalDomain,
-					"record_type": "A",
-					"records":     ips,
-					"ttl":         ttl,
-				})
-				log.Printf("[DNS Pusher] Added DNS record for database %s (domain: %s)", row.DatabaseID, canonicalDomain)
-
-				legacyDomain := fmt.Sprintf("%s.my.obiente.cloud", row.DatabaseID)
-				if legacyDomain != canonicalDomain {
-					records = append(records, map[string]interface{}{
-						"domain":      legacyDomain,
-						"record_type": "A",
-						"records":     ips,
-						"ttl":         ttl,
-					})
-					log.Printf("[DNS Pusher] Added legacy DNS record for database %s (domain: %s)", row.DatabaseID, legacyDomain)
-				}
-			} else {
-				log.Printf("[DNS Pusher] No node IPs available for database %s", row.DatabaseID)
-			}
-		}
+		records = append(records, collectDatabaseDNSRecords(databaseRows, nodeIPMap, ttl)...)
 	}
 
 	// Get all running game servers
@@ -1529,6 +1486,42 @@ func pushDNSRecords(ctx context.Context, client *http.Client, pushURL, apiKey, s
 			log.Printf("[DNS Pusher] Push errors: %v", errors)
 		}
 	}
+}
+
+func collectDatabaseDNSRecords(rows []databaseDNSRow, nodeIPMap map[string][]string, ttl int64) []map[string]interface{} {
+	records := make([]map[string]interface{}, 0, len(rows)*2)
+	for _, row := range rows {
+		ips, err := database.GetDatabaseNodeIP(row.DatabaseID, nodeIPMap)
+		if err != nil {
+			log.Printf("[DNS Pusher] Skipping database %s because its host node could not be resolved: %v", row.DatabaseID, err)
+			continue
+		}
+		if len(ips) == 0 {
+			log.Printf("[DNS Pusher] No node IPs available for database %s", row.DatabaseID)
+			continue
+		}
+
+		canonicalDomain := database.DefaultMyObienteCloudDomain(row.DatabaseID)
+		records = append(records, map[string]interface{}{
+			"domain":      canonicalDomain,
+			"record_type": "A",
+			"records":     ips,
+			"ttl":         ttl,
+		})
+		log.Printf("[DNS Pusher] Added DNS record for database %s (domain: %s)", row.DatabaseID, canonicalDomain)
+
+		legacyDomain := fmt.Sprintf("%s.my.obiente.cloud", row.DatabaseID)
+		if legacyDomain != canonicalDomain {
+			records = append(records, map[string]interface{}{
+				"domain":      legacyDomain,
+				"record_type": "A",
+				"records":     ips,
+				"ttl":         ttl,
+			})
+			log.Printf("[DNS Pusher] Added legacy DNS record for database %s (domain: %s)", row.DatabaseID, legacyDomain)
+		}
+	}
+	return records
 }
 
 func startDelegatedRecordCleanup(ctx context.Context) {

--- a/apps/dns-service/main_test.go
+++ b/apps/dns-service/main_test.go
@@ -1,14 +1,11 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/miekg/dns"
-	"github.com/obiente/cloud/apps/shared/pkg/database"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
@@ -43,38 +40,17 @@ func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
 }
 
 func TestCollectDatabaseDNSRecordsSkipsUnresolvedOwner(t *testing.T) {
-	previousDB := database.DB
-	db, err := gorm.Open(sqlite.Open("file:dns-pusher-owner-test?mode=memory&cache=shared"), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("open test database: %v", err)
-	}
-	database.DB = db
-	t.Cleanup(func() { database.DB = previousDB })
-	if err := db.AutoMigrate(&database.DatabaseInstance{}, &database.DatabaseLocation{}, &database.NodeMetadata{}); err != nil {
-		t.Fatalf("migrate test database: %v", err)
-	}
-
 	databaseID := "db-dns-pusher-owner-test"
-	containerID := "container-dns-pusher-owner-test"
-	if err := db.Create(&database.DatabaseInstance{ID: databaseID, InstanceID: &containerID}).Error; err != nil {
-		t.Fatalf("create database instance: %v", err)
-	}
-	if err := db.Create(&database.DatabaseLocation{
-		ID:          database.DatabaseLocationID(databaseID, containerID),
-		DatabaseID:  databaseID,
-		NodeID:      "missing-owner-node",
-		NodeIP:      "203.0.113.55",
-		ContainerID: containerID,
-		Status:      "running",
-		UpdatedAt:   time.Now(),
-	}).Error; err != nil {
-		t.Fatalf("create database location: %v", err)
-	}
-
 	records := collectDatabaseDNSRecords(
 		[]databaseDNSRow{{DatabaseID: databaseID}},
 		map[string][]string{"default": {"192.0.2.10"}},
 		60,
+		func(gotDatabaseID string, _ map[string][]string) ([]string, error) {
+			if gotDatabaseID != databaseID {
+				t.Fatalf("resolver database ID = %q, want %q", gotDatabaseID, databaseID)
+			}
+			return nil, errors.New("synthetic unresolved owner")
+		},
 	)
 	if len(records) != 0 {
 		t.Fatalf("expected unresolved database owner to be omitted, got %#v", records)

--- a/apps/dns-service/main_test.go
+++ b/apps/dns-service/main_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/obiente/cloud/apps/shared/pkg/database"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
@@ -35,6 +39,45 @@ func TestNormalizePreviewACMEChallengeCNAME(t *testing.T) {
 
 	if _, err := normalizePreviewACMEChallengeCNAME(""); err != nil {
 		t.Fatalf("empty optional CNAME: %v", err)
+	}
+}
+
+func TestCollectDatabaseDNSRecordsSkipsUnresolvedOwner(t *testing.T) {
+	previousDB := database.DB
+	db, err := gorm.Open(sqlite.Open("file:dns-pusher-owner-test?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = previousDB })
+	if err := db.AutoMigrate(&database.DatabaseInstance{}, &database.DatabaseLocation{}, &database.NodeMetadata{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	databaseID := "db-dns-pusher-owner-test"
+	containerID := "container-dns-pusher-owner-test"
+	if err := db.Create(&database.DatabaseInstance{ID: databaseID, InstanceID: &containerID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := db.Create(&database.DatabaseLocation{
+		ID:          database.DatabaseLocationID(databaseID, containerID),
+		DatabaseID:  databaseID,
+		NodeID:      "missing-owner-node",
+		NodeIP:      "203.0.113.55",
+		ContainerID: containerID,
+		Status:      "running",
+		UpdatedAt:   time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create database location: %v", err)
+	}
+
+	records := collectDatabaseDNSRecords(
+		[]databaseDNSRow{{DatabaseID: databaseID}},
+		map[string][]string{"default": {"192.0.2.10"}},
+		60,
+	)
+	if len(records) != 0 {
+		t.Fatalf("expected unresolved database owner to be omitted, got %#v", records)
 	}
 }
 

--- a/apps/shared/pkg/database/database_repository.go
+++ b/apps/shared/pkg/database/database_repository.go
@@ -211,7 +211,7 @@ func (r *DatabaseConnectionRepository) GetByDatabaseID(ctx context.Context, data
 func (r *DatabaseConnectionRepository) Update(ctx context.Context, conn *DatabaseConnection) error {
 	return r.db.WithContext(ctx).
 		Model(conn).
-		Select("username", "password", "database_name", "host", "port", "ssl_required", "ssl_certificate", "updated_at").
+		Select("username", "password", "database_name", "host", "port", "proxy_port", "ssl_required", "ssl_certificate", "updated_at").
 		Updates(conn).Error
 }
 

--- a/apps/shared/pkg/database/database_repository.go
+++ b/apps/shared/pkg/database/database_repository.go
@@ -152,6 +152,20 @@ func (r *DatabaseRepository) Update(ctx context.Context, database *DatabaseInsta
 	return nil
 }
 
+func UpdateDatabaseInstanceStatus(ctx context.Context, databaseID string, status int32) error {
+	if err := DB.WithContext(ctx).Model(&DatabaseInstance{}).
+		Where("id = ?", databaseID).
+		Update("status", status).Error; err != nil {
+		return err
+	}
+	if RedisClient != nil {
+		if err := RedisClient.Delete(ctx, fmt.Sprintf("database:%s", databaseID)); err != nil {
+			return fmt.Errorf("invalidate database instance cache: %w", err)
+		}
+	}
+	return nil
+}
+
 func (r *DatabaseRepository) Delete(ctx context.Context, id string) error {
 	// Soft delete
 	now := time.Now()

--- a/apps/shared/pkg/database/database_repository.go
+++ b/apps/shared/pkg/database/database_repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type DatabaseRepository struct {
@@ -198,6 +199,16 @@ func NewDatabaseConnectionRepository(db *gorm.DB) *DatabaseConnectionRepository 
 
 func (r *DatabaseConnectionRepository) Create(ctx context.Context, conn *DatabaseConnection) error {
 	return r.db.WithContext(ctx).Create(conn).Error
+}
+
+func (r *DatabaseConnectionRepository) CreateOrUpdate(ctx context.Context, conn *DatabaseConnection) error {
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "database_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"database_name", "username", "password", "host", "port", "proxy_port",
+			"ssl_required", "ssl_certificate", "updated_at",
+		}),
+	}).Create(conn).Error
 }
 
 func (r *DatabaseConnectionRepository) GetByDatabaseID(ctx context.Context, databaseID string) (*DatabaseConnection, error) {

--- a/apps/shared/pkg/database/database_repository.go
+++ b/apps/shared/pkg/database/database_repository.go
@@ -152,20 +152,6 @@ func (r *DatabaseRepository) Update(ctx context.Context, database *DatabaseInsta
 	return nil
 }
 
-func UpdateDatabaseInstanceStatus(ctx context.Context, databaseID string, status int32) error {
-	if err := DB.WithContext(ctx).Model(&DatabaseInstance{}).
-		Where("id = ?", databaseID).
-		Update("status", status).Error; err != nil {
-		return err
-	}
-	if RedisClient != nil {
-		if err := RedisClient.Delete(ctx, fmt.Sprintf("database:%s", databaseID)); err != nil {
-			return fmt.Errorf("invalidate database instance cache: %w", err)
-		}
-	}
-	return nil
-}
-
 func (r *DatabaseRepository) Delete(ctx context.Context, id string) error {
 	// Soft delete
 	now := time.Now()

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -26,6 +27,20 @@ type DatabaseLocation struct {
 }
 
 func (DatabaseLocation) TableName() string { return "database_locations" }
+
+// DatabaseUptimeInterval records one continuous period in which a managed
+// database was running. Separate intervals prevent stopped time from being
+// counted after a database starts again.
+type DatabaseUptimeInterval struct {
+	ID          string     `gorm:"primaryKey" json:"id"`
+	DatabaseID  string     `gorm:"index;not null" json:"database_id"`
+	ContainerID string     `gorm:"index;not null" json:"container_id"`
+	NodeID      string     `gorm:"index;not null" json:"node_id"`
+	StartedAt   time.Time  `gorm:"index;not null" json:"started_at"`
+	EndedAt     *time.Time `gorm:"index" json:"ended_at"`
+}
+
+func (DatabaseUptimeInterval) TableName() string { return "database_uptime_intervals" }
 
 // DatabaseLocationID returns a stable primary key for a database container's
 // location record, allowing startup reconciliation to safely upsert it.
@@ -49,14 +64,22 @@ func GetAllDatabaseLocations(databaseID string) ([]DatabaseLocation, error) {
 
 // UpsertDatabaseLocation creates or updates a database location
 func UpsertDatabaseLocation(location *DatabaseLocation) error {
-	var existing DatabaseLocation
-	if err := DB.Where("container_id = ?", location.ContainerID).First(&existing).Error; err == nil {
-		location.ID = existing.ID
-		location.CreatedAt = existing.CreatedAt
-	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
-	}
-	return DB.Save(location).Error
+	return DB.Transaction(func(tx *gorm.DB) error {
+		var existing DatabaseLocation
+		if err := tx.Where("container_id = ?", location.ContainerID).First(&existing).Error; err == nil {
+			location.ID = existing.ID
+			location.CreatedAt = existing.CreatedAt
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		if err := tx.Save(location).Error; err != nil {
+			return err
+		}
+		if location.Status == "running" {
+			return ensureDatabaseUptimeInterval(tx, location, time.Now().UTC())
+		}
+		return closeDatabaseUptimeIntervals(tx, location.DatabaseID, time.Now().UTC())
+	})
 }
 
 // DeleteDatabaseLocation removes a database location
@@ -67,12 +90,71 @@ func DeleteDatabaseLocation(containerID string) error {
 // UpdateDatabaseLocationStatus keeps location-based metrics aligned with the
 // managed database lifecycle.
 func UpdateDatabaseLocationStatus(ctx context.Context, databaseID, status string) error {
-	return DB.WithContext(ctx).Model(&DatabaseLocation{}).
-		Where("database_id = ?", databaseID).
-		Updates(map[string]interface{}{
-			"status":     status,
-			"updated_at": time.Now(),
-		}).Error
+	now := time.Now().UTC()
+	return DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var locations []DatabaseLocation
+		if err := tx.Where("database_id = ?", databaseID).Find(&locations).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&DatabaseLocation{}).
+			Where("database_id = ?", databaseID).
+			Updates(map[string]interface{}{"status": status, "updated_at": now}).Error; err != nil {
+			return err
+		}
+		if status != "running" {
+			return closeDatabaseUptimeIntervals(tx, databaseID, now)
+		}
+		for i := range locations {
+			locations[i].Status = status
+			if err := ensureDatabaseUptimeInterval(tx, &locations[i], now); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// EnsureDatabaseUptimeInterval backfills an open interval for a running
+// location discovered during startup reconciliation.
+func EnsureDatabaseUptimeInterval(ctx context.Context, databaseID string) error {
+	now := time.Now().UTC()
+	return DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var locations []DatabaseLocation
+		if err := tx.Where("database_id = ? AND status = ?", databaseID, "running").Find(&locations).Error; err != nil {
+			return err
+		}
+		for i := range locations {
+			if err := ensureDatabaseUptimeInterval(tx, &locations[i], now); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func ensureDatabaseUptimeInterval(tx *gorm.DB, location *DatabaseLocation, now time.Time) error {
+	var count int64
+	if err := tx.Model(&DatabaseUptimeInterval{}).
+		Where("database_id = ? AND container_id = ? AND ended_at IS NULL", location.DatabaseID, location.ContainerID).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	return tx.Create(&DatabaseUptimeInterval{
+		ID:          uuid.NewString(),
+		DatabaseID:  location.DatabaseID,
+		ContainerID: location.ContainerID,
+		NodeID:      location.NodeID,
+		StartedAt:   now,
+	}).Error
+}
+
+func closeDatabaseUptimeIntervals(tx *gorm.DB, databaseID string, now time.Time) error {
+	return tx.Model(&DatabaseUptimeInterval{}).
+		Where("database_id = ? AND ended_at IS NULL", databaseID).
+		Update("ended_at", now).Error
 }
 
 // RecordDatabaseMetrics records database metrics

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/obiente/cloud/apps/shared/pkg/logger"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -151,8 +152,28 @@ func UpdateDatabaseRuntimeStatus(ctx context.Context, databaseID string, instanc
 		return err
 	}
 	if RedisClient != nil {
-		if err := RedisClient.Delete(ctx, fmt.Sprintf("database:%s", databaseID)); err != nil {
-			return fmt.Errorf("invalidate database instance cache: %w", err)
+		var cacheErr error
+		for attempt := 1; attempt <= 3; attempt++ {
+			if cacheErr = RedisClient.Delete(ctx, fmt.Sprintf("database:%s", databaseID)); cacheErr == nil {
+				break
+			}
+			if attempt < 3 {
+				timer := time.NewTimer(100 * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					attempt = 3
+				case <-timer.C:
+				}
+			}
+		}
+		if cacheErr != nil {
+			logger.Warn("Database %s runtime status committed, but cache invalidation failed: %v", databaseID, cacheErr)
 		}
 	}
 	return nil

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -120,6 +120,44 @@ func UpdateDatabaseLocationStatus(ctx context.Context, databaseID, status string
 	})
 }
 
+// UpdateDatabaseRuntimeStatus commits the instance and its location/uptime
+// state together so reconciliation cannot leave a split lifecycle transition.
+func UpdateDatabaseRuntimeStatus(ctx context.Context, databaseID string, instanceStatus int32, locationStatus string) error {
+	now := time.Now().UTC()
+	if err := DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&DatabaseInstance{}).
+			Where("id = ?", databaseID).
+			Update("status", instanceStatus).Error; err != nil {
+			return err
+		}
+		location, err := currentDatabaseLocation(tx, databaseID)
+		if err != nil || location == nil {
+			return err
+		}
+		if err := deactivateOtherDatabaseLocations(tx, databaseID, location.ContainerID, now); err != nil {
+			return err
+		}
+		if err := tx.Model(&DatabaseLocation{}).
+			Where("id = ?", location.ID).
+			Updates(map[string]interface{}{"status": locationStatus, "updated_at": now}).Error; err != nil {
+			return err
+		}
+		if locationStatus != "running" {
+			return closeDatabaseUptimeIntervals(tx, databaseID, location.ContainerID, now)
+		}
+		location.Status = locationStatus
+		return ensureDatabaseUptimeInterval(tx, location, now)
+	}); err != nil {
+		return err
+	}
+	if RedisClient != nil {
+		if err := RedisClient.Delete(ctx, fmt.Sprintf("database:%s", databaseID)); err != nil {
+			return fmt.Errorf("invalidate database instance cache: %w", err)
+		}
+	}
+	return nil
+}
+
 // EnsureDatabaseUptimeInterval backfills an open interval for a running
 // location discovered during startup reconciliation.
 func EnsureDatabaseUptimeInterval(ctx context.Context, databaseID string) error {

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -216,7 +216,7 @@ func currentDatabaseLocation(tx *gorm.DB, databaseID string) (*DatabaseLocation,
 }
 
 func deactivateOtherDatabaseLocations(tx *gorm.DB, databaseID, currentContainerID string, now time.Time) error {
-	activeStatuses := []string{"running", "restarting", "starting", "created"}
+	activeStatuses := []string{"running", "restarting", "starting", "created", "sleeping"}
 	if err := tx.Model(&DatabaseLocation{}).
 		Where("database_id = ? AND container_id <> ? AND status IN ?", databaseID, currentContainerID, activeStatuses).
 		Updates(map[string]interface{}{"status": "stopped", "updated_at": now}).Error; err != nil {

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -2,7 +2,11 @@ package database
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // DatabaseLocation tracks where managed database containers are running across the cluster
@@ -23,6 +27,12 @@ type DatabaseLocation struct {
 
 func (DatabaseLocation) TableName() string { return "database_locations" }
 
+// DatabaseLocationID returns a stable primary key for a database container's
+// location record, allowing startup reconciliation to safely upsert it.
+func DatabaseLocationID(databaseID, containerID string) string {
+	return fmt.Sprintf("%s:%s", databaseID, containerID)
+}
+
 // GetDatabaseLocations returns all locations where a database is running
 func GetDatabaseLocations(databaseID string) ([]DatabaseLocation, error) {
 	var locations []DatabaseLocation
@@ -39,6 +49,13 @@ func GetAllDatabaseLocations(databaseID string) ([]DatabaseLocation, error) {
 
 // UpsertDatabaseLocation creates or updates a database location
 func UpsertDatabaseLocation(location *DatabaseLocation) error {
+	var existing DatabaseLocation
+	if err := DB.Where("container_id = ?", location.ContainerID).First(&existing).Error; err == nil {
+		location.ID = existing.ID
+		location.CreatedAt = existing.CreatedAt
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
 	return DB.Save(location).Error
 }
 

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -209,6 +209,49 @@ func EnsureDatabaseUptimeInterval(ctx context.Context, databaseID string) error 
 func BackfillDatabaseUptimeIntervals() error {
 	now := time.Now().UTC()
 	return DB.Transaction(func(tx *gorm.DB) error {
+		var instances []DatabaseInstance
+		if err := tx.Select("id", "instance_id").Find(&instances).Error; err != nil {
+			return err
+		}
+		authoritativeContainers := make(map[string]string, len(instances))
+		for i := range instances {
+			if instances[i].InstanceID != nil && *instances[i].InstanceID != "" {
+				authoritativeContainers[instances[i].ID] = *instances[i].InstanceID
+			}
+		}
+
+		var legacyLocations []DatabaseLocation
+		if err := tx.Order("database_id, updated_at DESC").Find(&legacyLocations).Error; err != nil {
+			return err
+		}
+		for i := range legacyLocations {
+			location := &legacyLocations[i]
+			if location.Status == "running" && authoritativeContainers[location.DatabaseID] == "" {
+				authoritativeContainers[location.DatabaseID] = location.ContainerID
+			}
+		}
+		for i := range legacyLocations {
+			location := &legacyLocations[i]
+			currentContainerID := authoritativeContainers[location.DatabaseID]
+			if location.Status != "running" || currentContainerID == "" || location.ContainerID == currentContainerID {
+				continue
+			}
+			endedAt := location.UpdatedAt.UTC()
+			if endedAt.IsZero() {
+				endedAt = now
+			}
+			if err := tx.Model(&DatabaseLocation{}).
+				Where("id = ?", location.ID).
+				Update("status", "stopped").Error; err != nil {
+				return err
+			}
+			if err := tx.Model(&DatabaseUptimeInterval{}).
+				Where("database_id = ? AND container_id = ? AND ended_at IS NULL", location.DatabaseID, location.ContainerID).
+				Update("ended_at", endedAt).Error; err != nil {
+				return err
+			}
+		}
+
 		var locations []DatabaseLocation
 		if err := tx.Table("database_locations AS dl").
 			Select("dl.*").

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -64,6 +64,17 @@ func DeleteDatabaseLocation(containerID string) error {
 	return DB.Where("container_id = ?", containerID).Delete(&DatabaseLocation{}).Error
 }
 
+// UpdateDatabaseLocationStatus keeps location-based metrics aligned with the
+// managed database lifecycle.
+func UpdateDatabaseLocationStatus(ctx context.Context, databaseID, status string) error {
+	return DB.WithContext(ctx).Model(&DatabaseLocation{}).
+		Where("database_id = ?", databaseID).
+		Updates(map[string]interface{}{
+			"status":     status,
+			"updated_at": time.Now(),
+		}).Error
+}
+
 // RecordDatabaseMetrics records database metrics
 func RecordDatabaseMetrics(ctx context.Context, metrics *DatabaseMetrics) error {
 	targetDB := MetricsDB

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -150,20 +150,15 @@ func BackfillDatabaseUptimeIntervals() error {
 	now := time.Now().UTC()
 	return DB.Transaction(func(tx *gorm.DB) error {
 		var locations []DatabaseLocation
-		if err := tx.Find(&locations).Error; err != nil {
+		if err := tx.Table("database_locations AS dl").
+			Select("dl.*").
+			Joins("LEFT JOIN database_uptime_intervals AS dui ON dui.database_id = dl.database_id AND dui.container_id = dl.container_id").
+			Where("dui.id IS NULL").
+			Find(&locations).Error; err != nil {
 			return err
 		}
+		intervals := make([]DatabaseUptimeInterval, 0, len(locations))
 		for i := range locations {
-			var count int64
-			if err := tx.Model(&DatabaseUptimeInterval{}).
-				Where("database_id = ? AND container_id = ?", locations[i].DatabaseID, locations[i].ContainerID).
-				Count(&count).Error; err != nil {
-				return err
-			}
-			if count > 0 {
-				continue
-			}
-
 			startedAt := locations[i].CreatedAt.UTC()
 			if startedAt.IsZero() {
 				startedAt = locations[i].UpdatedAt.UTC()
@@ -171,7 +166,7 @@ func BackfillDatabaseUptimeIntervals() error {
 			if startedAt.IsZero() {
 				startedAt = now
 			}
-			interval := &DatabaseUptimeInterval{
+			interval := DatabaseUptimeInterval{
 				ID:          uuid.NewString(),
 				DatabaseID:  locations[i].DatabaseID,
 				ContainerID: locations[i].ContainerID,
@@ -185,11 +180,12 @@ func BackfillDatabaseUptimeIntervals() error {
 				}
 				interval.EndedAt = &endedAt
 			}
-			if err := tx.Create(interval).Error; err != nil {
-				return err
-			}
+			intervals = append(intervals, interval)
 		}
-		return nil
+		if len(intervals) == 0 {
+			return nil
+		}
+		return tx.CreateInBatches(intervals, 500).Error
 	})
 }
 

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // DatabaseLocation tracks where managed database containers are running across the cluster
@@ -33,8 +34,8 @@ func (DatabaseLocation) TableName() string { return "database_locations" }
 // counted after a database starts again.
 type DatabaseUptimeInterval struct {
 	ID          string     `gorm:"primaryKey" json:"id"`
-	DatabaseID  string     `gorm:"index;not null" json:"database_id"`
-	ContainerID string     `gorm:"index;not null" json:"container_id"`
+	DatabaseID  string     `gorm:"index;not null;uniqueIndex:idx_database_uptime_open,where:ended_at IS NULL" json:"database_id"`
+	ContainerID string     `gorm:"index;not null;uniqueIndex:idx_database_uptime_open,where:ended_at IS NULL" json:"container_id"`
 	NodeID      string     `gorm:"index;not null" json:"node_id"`
 	StartedAt   time.Time  `gorm:"index;not null" json:"started_at"`
 	EndedAt     *time.Time `gorm:"index" json:"ended_at"`
@@ -185,7 +186,7 @@ func BackfillDatabaseUptimeIntervals() error {
 		if len(intervals) == 0 {
 			return nil
 		}
-		return tx.CreateInBatches(intervals, 500).Error
+		return tx.Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(intervals, 500).Error
 	})
 }
 
@@ -227,16 +228,7 @@ func deactivateOtherDatabaseLocations(tx *gorm.DB, databaseID, currentContainerI
 }
 
 func ensureDatabaseUptimeInterval(tx *gorm.DB, location *DatabaseLocation, now time.Time) error {
-	var count int64
-	if err := tx.Model(&DatabaseUptimeInterval{}).
-		Where("database_id = ? AND container_id = ? AND ended_at IS NULL", location.DatabaseID, location.ContainerID).
-		Count(&count).Error; err != nil {
-		return err
-	}
-	if count > 0 {
-		return nil
-	}
-	return tx.Create(&DatabaseUptimeInterval{
+	return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&DatabaseUptimeInterval{
 		ID:          uuid.NewString(),
 		DatabaseID:  location.DatabaseID,
 		ContainerID: location.ContainerID,

--- a/apps/shared/pkg/database/database_tracking.go
+++ b/apps/shared/pkg/database/database_tracking.go
@@ -65,6 +65,7 @@ func GetAllDatabaseLocations(databaseID string) ([]DatabaseLocation, error) {
 // UpsertDatabaseLocation creates or updates a database location
 func UpsertDatabaseLocation(location *DatabaseLocation) error {
 	return DB.Transaction(func(tx *gorm.DB) error {
+		now := time.Now().UTC()
 		var existing DatabaseLocation
 		if err := tx.Where("container_id = ?", location.ContainerID).First(&existing).Error; err == nil {
 			location.ID = existing.ID
@@ -75,10 +76,13 @@ func UpsertDatabaseLocation(location *DatabaseLocation) error {
 		if err := tx.Save(location).Error; err != nil {
 			return err
 		}
-		if location.Status == "running" {
-			return ensureDatabaseUptimeInterval(tx, location, time.Now().UTC())
+		if err := deactivateOtherDatabaseLocations(tx, location.DatabaseID, location.ContainerID, now); err != nil {
+			return err
 		}
-		return closeDatabaseUptimeIntervals(tx, location.DatabaseID, time.Now().UTC())
+		if location.Status == "running" {
+			return ensureDatabaseUptimeInterval(tx, location, now)
+		}
+		return closeDatabaseUptimeIntervals(tx, location.DatabaseID, location.ContainerID, now)
 	})
 }
 
@@ -92,25 +96,26 @@ func DeleteDatabaseLocation(containerID string) error {
 func UpdateDatabaseLocationStatus(ctx context.Context, databaseID, status string) error {
 	now := time.Now().UTC()
 	return DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var locations []DatabaseLocation
-		if err := tx.Where("database_id = ?", databaseID).Find(&locations).Error; err != nil {
+		location, err := currentDatabaseLocation(tx, databaseID)
+		if err != nil {
+			return err
+		}
+		if location == nil {
+			return nil
+		}
+		if err := deactivateOtherDatabaseLocations(tx, databaseID, location.ContainerID, now); err != nil {
 			return err
 		}
 		if err := tx.Model(&DatabaseLocation{}).
-			Where("database_id = ?", databaseID).
+			Where("id = ?", location.ID).
 			Updates(map[string]interface{}{"status": status, "updated_at": now}).Error; err != nil {
 			return err
 		}
 		if status != "running" {
-			return closeDatabaseUptimeIntervals(tx, databaseID, now)
+			return closeDatabaseUptimeIntervals(tx, databaseID, location.ContainerID, now)
 		}
-		for i := range locations {
-			locations[i].Status = status
-			if err := ensureDatabaseUptimeInterval(tx, &locations[i], now); err != nil {
-				return err
-			}
-		}
-		return nil
+		location.Status = status
+		return ensureDatabaseUptimeInterval(tx, location, now)
 	})
 }
 
@@ -119,17 +124,110 @@ func UpdateDatabaseLocationStatus(ctx context.Context, databaseID, status string
 func EnsureDatabaseUptimeInterval(ctx context.Context, databaseID string) error {
 	now := time.Now().UTC()
 	return DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		location, err := currentDatabaseLocation(tx, databaseID)
+		if err != nil {
+			return err
+		}
+		if location == nil {
+			return nil
+		}
+		if err := deactivateOtherDatabaseLocations(tx, databaseID, location.ContainerID, now); err != nil {
+			return err
+		}
+		if location.Status != "running" {
+			return closeDatabaseUptimeIntervals(tx, databaseID, location.ContainerID, now)
+		}
+		return ensureDatabaseUptimeInterval(tx, location, now)
+	})
+}
+
+// BackfillDatabaseUptimeIntervals preserves the best interval available from
+// legacy location timestamps before usage reads switch to the interval table.
+// A legacy row cannot describe earlier stop/start cycles, so the migration
+// retains its previous continuous-lifetime interpretation without inventing
+// more precise history.
+func BackfillDatabaseUptimeIntervals() error {
+	now := time.Now().UTC()
+	return DB.Transaction(func(tx *gorm.DB) error {
 		var locations []DatabaseLocation
-		if err := tx.Where("database_id = ? AND status = ?", databaseID, "running").Find(&locations).Error; err != nil {
+		if err := tx.Find(&locations).Error; err != nil {
 			return err
 		}
 		for i := range locations {
-			if err := ensureDatabaseUptimeInterval(tx, &locations[i], now); err != nil {
+			var count int64
+			if err := tx.Model(&DatabaseUptimeInterval{}).
+				Where("database_id = ? AND container_id = ?", locations[i].DatabaseID, locations[i].ContainerID).
+				Count(&count).Error; err != nil {
+				return err
+			}
+			if count > 0 {
+				continue
+			}
+
+			startedAt := locations[i].CreatedAt.UTC()
+			if startedAt.IsZero() {
+				startedAt = locations[i].UpdatedAt.UTC()
+			}
+			if startedAt.IsZero() {
+				startedAt = now
+			}
+			interval := &DatabaseUptimeInterval{
+				ID:          uuid.NewString(),
+				DatabaseID:  locations[i].DatabaseID,
+				ContainerID: locations[i].ContainerID,
+				NodeID:      locations[i].NodeID,
+				StartedAt:   startedAt,
+			}
+			if locations[i].Status != "running" {
+				endedAt := locations[i].UpdatedAt.UTC()
+				if endedAt.IsZero() || endedAt.Before(startedAt) {
+					endedAt = startedAt
+				}
+				interval.EndedAt = &endedAt
+			}
+			if err := tx.Create(interval).Error; err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+func currentDatabaseLocation(tx *gorm.DB, databaseID string) (*DatabaseLocation, error) {
+	var instance DatabaseInstance
+	if err := tx.Select("instance_id").First(&instance, "id = ?", databaseID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	query := tx.Where("database_id = ?", databaseID)
+	if instance.InstanceID != nil && *instance.InstanceID != "" {
+		query = query.Where("container_id = ?", *instance.InstanceID)
+	} else {
+		query = query.Order("updated_at DESC")
+	}
+	var location DatabaseLocation
+	if err := query.First(&location).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &location, nil
+}
+
+func deactivateOtherDatabaseLocations(tx *gorm.DB, databaseID, currentContainerID string, now time.Time) error {
+	activeStatuses := []string{"running", "restarting", "starting", "created"}
+	if err := tx.Model(&DatabaseLocation{}).
+		Where("database_id = ? AND container_id <> ? AND status IN ?", databaseID, currentContainerID, activeStatuses).
+		Updates(map[string]interface{}{"status": "stopped", "updated_at": now}).Error; err != nil {
+		return err
+	}
+	return tx.Model(&DatabaseUptimeInterval{}).
+		Where("database_id = ? AND container_id <> ? AND ended_at IS NULL", databaseID, currentContainerID).
+		Update("ended_at", now).Error
 }
 
 func ensureDatabaseUptimeInterval(tx *gorm.DB, location *DatabaseLocation, now time.Time) error {
@@ -151,9 +249,9 @@ func ensureDatabaseUptimeInterval(tx *gorm.DB, location *DatabaseLocation, now t
 	}).Error
 }
 
-func closeDatabaseUptimeIntervals(tx *gorm.DB, databaseID string, now time.Time) error {
+func closeDatabaseUptimeIntervals(tx *gorm.DB, databaseID, containerID string, now time.Time) error {
 	return tx.Model(&DatabaseUptimeInterval{}).
-		Where("database_id = ? AND ended_at IS NULL", databaseID).
+		Where("database_id = ? AND container_id = ? AND ended_at IS NULL", databaseID, containerID).
 		Update("ended_at", now).Error
 }
 

--- a/apps/shared/pkg/database/deployment_tracking.go
+++ b/apps/shared/pkg/database/deployment_tracking.go
@@ -125,6 +125,7 @@ func InitDeploymentTracking() error {
 		&GameServerDomainVerification{},
 		&GameServerLocation{},
 		&DatabaseLocation{},
+		&DatabaseUptimeInterval{},
 	); err != nil {
 		return err
 	}

--- a/apps/shared/pkg/database/deployment_tracking.go
+++ b/apps/shared/pkg/database/deployment_tracking.go
@@ -129,6 +129,9 @@ func InitDeploymentTracking() error {
 	); err != nil {
 		return err
 	}
+	if err := BackfillDatabaseUptimeIntervals(); err != nil {
+		return fmt.Errorf("backfill database uptime intervals: %w", err)
+	}
 
 	// Note: DeploymentMetrics and DeploymentUsageHourly are now handled by InitMetricsTables
 	// to use the separate metrics database

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -215,7 +215,7 @@ func GetDatabaseNodeIP(databaseID string, nodeIPMap map[string][]string) ([]stri
 	}
 
 	var locations []DatabaseLocation
-	if err := DB.Where("database_id = ? AND status IN ?", databaseID, []string{"running", "restarting", "starting", "created"}).
+	if err := DB.Where("database_id = ? AND status IN ?", databaseID, []string{"running", "restarting", "starting", "created", "sleeping"}).
 		Order("updated_at DESC").
 		Find(&locations).Error; err != nil {
 		return nil, fmt.Errorf("failed to query database locations: %w", err)

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -85,7 +85,7 @@ func GetGameServerNodeIP(gameServerID string, nodeIPMap map[string][]string) ([]
 }
 
 func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string) ([]string, error) {
-	if explicitNodeIP = strings.TrimSpace(explicitNodeIP); explicitNodeIP != "" {
+	if explicitNodeIP = strings.TrimSpace(explicitNodeIP); configuredNodeIP(explicitNodeIP, nodeIPMap) {
 		return []string{explicitNodeIP}, nil
 	}
 
@@ -101,7 +101,7 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 		return nil, fmt.Errorf("failed to find node %s: %w", nodeID, err)
 	}
 
-	if node.IP = strings.TrimSpace(node.IP); node.IP != "" {
+	if node.IP = strings.TrimSpace(node.IP); configuredNodeIP(node.IP, nodeIPMap) {
 		return []string{node.IP}, nil
 	}
 
@@ -123,6 +123,21 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 	}
 
 	return ips, nil
+}
+
+func configuredNodeIP(candidate string, nodeIPMap map[string][]string) bool {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return false
+	}
+	for _, rawIPs := range nodeIPMap {
+		for _, configuredIP := range rawIPs {
+			if strings.TrimSpace(configuredIP) == candidate {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func compatibilityNodeIPs(nodeIPMap map[string][]string, reason string) ([]string, error) {

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -85,16 +85,25 @@ func GetGameServerNodeIP(gameServerID string, nodeIPMap map[string][]string) ([]
 }
 
 func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string) ([]string, error) {
-	return resolveNodeIPs(nodeID, explicitNodeIP, nodeIPMap, true)
+	return resolveNodeIPs(nodeID, "", explicitNodeIP, nodeIPMap, true)
 }
 
 func resolveAuthoritativeNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string) ([]string, error) {
-	return resolveNodeIPs(nodeID, explicitNodeIP, nodeIPMap, false)
+	return resolveNodeIPs(nodeID, "", explicitNodeIP, nodeIPMap, false)
 }
 
-func resolveNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string, allowCompatibilityFallback bool) ([]string, error) {
+func resolveAuthoritativeLocationNodeIPs(nodeID, nodeHostname, explicitNodeIP string, nodeIPMap map[string][]string) ([]string, error) {
+	return resolveNodeIPs(nodeID, nodeHostname, explicitNodeIP, nodeIPMap, false)
+}
+
+func resolveNodeIPs(nodeID, nodeHostname, explicitNodeIP string, nodeIPMap map[string][]string, allowCompatibilityFallback bool) ([]string, error) {
 	if explicitNodeIP = strings.TrimSpace(explicitNodeIP); configuredNodeIP(explicitNodeIP, nodeIPMap) {
 		return []string{explicitNodeIP}, nil
+	}
+	if ips, found, err := keyedNodeIPs(nodeIPMap, nodeID, nodeHostname); err != nil {
+		return nil, err
+	} else if found {
+		return ips, nil
 	}
 
 	var node NodeMetadata
@@ -152,8 +161,12 @@ func resolveNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string
 }
 
 func nodeSpecificIPs(node NodeMetadata, nodeIPMap map[string][]string) ([]string, bool, error) {
-	keys := []string{strings.TrimSpace(node.ID), strings.TrimSpace(node.Hostname)}
+	return keyedNodeIPs(nodeIPMap, node.ID, node.Hostname)
+}
+
+func keyedNodeIPs(nodeIPMap map[string][]string, keys ...string) ([]string, bool, error) {
 	for _, key := range keys {
+		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
@@ -248,7 +261,7 @@ func GetDatabaseNodeIP(databaseID string, nodeIPMap map[string][]string) ([]stri
 	}
 	if len(locations) > 0 {
 		location := locations[0]
-		ips, err := resolveAuthoritativeNodeIPs(location.NodeID, location.NodeIP, nodeIPMap)
+		ips, err := resolveAuthoritativeLocationNodeIPs(location.NodeID, location.NodeHostname, location.NodeIP, nodeIPMap)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve active database location on node %s: %w", location.NodeID, err)
 		}

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -115,6 +115,11 @@ func resolveNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string
 	if node.IP = strings.TrimSpace(node.IP); configuredNodeIP(node.IP, nodeIPMap) {
 		return []string{node.IP}, nil
 	}
+	if ips, found, err := nodeSpecificIPs(node, nodeIPMap); err != nil {
+		return nil, err
+	} else if found {
+		return ips, nil
+	}
 
 	nodeRegion = node.Region
 
@@ -127,8 +132,8 @@ func resolveNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string
 	}
 
 	// Get node IPs for this region
-	ips, ok := nodeIPMap[nodeRegion]
-	if !ok || len(ips) == 0 {
+	ips := cleanNodeIPs(nodeIPMap[nodeRegion])
+	if len(ips) == 0 {
 		// Compatibility callers may use the historical default region. An
 		// authoritative database owner must never be replaced by another node.
 		if allowCompatibilityFallback {
@@ -139,8 +144,29 @@ func resolveNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string
 		}
 		return nil, fmt.Errorf("no node IP configured for region: %s", nodeRegion)
 	}
+	if !allowCompatibilityFallback && len(ips) != 1 {
+		return nil, fmt.Errorf("region %s contains %d node IPs; configure exactly one NODE_IPS entry for node %s or hostname %s", nodeRegion, len(ips), node.ID, node.Hostname)
+	}
 
 	return ips, nil
+}
+
+func nodeSpecificIPs(node NodeMetadata, nodeIPMap map[string][]string) ([]string, bool, error) {
+	keys := []string{strings.TrimSpace(node.ID), strings.TrimSpace(node.Hostname)}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		ips := cleanNodeIPs(nodeIPMap[key])
+		if len(ips) == 0 {
+			continue
+		}
+		if len(ips) != 1 {
+			return nil, false, fmt.Errorf("NODE_IPS entry %s contains %d addresses; node-specific entries must contain exactly one address", key, len(ips))
+		}
+		return ips, true, nil
+	}
+	return nil, false, nil
 }
 
 func configuredNodeIP(candidate string, nodeIPMap map[string][]string) bool {
@@ -265,10 +291,10 @@ func GetDeploymentRegion(deploymentID string) (string, error) {
 }
 
 // ParseNodeIPsFromEnv parses the NODE_IPS environment variable
-// Format: "region1:ip1,ip2;region2:ip3,ip4"
+// Format: "key1:ip1,ip2;key2:ip3,ip4", where keys may identify regions or nodes.
 // Also supports simple format: "ip1,ip2" (defaults to "default" region)
 // Also supports space-separated format: "region1:ip1,ip2 region2:ip3,ip4" (when semicolons are not present)
-// Returns a map of region -> []IP addresses
+// Returns a map of region or node key -> []IP addresses
 func ParseNodeIPsFromEnv(nodeIPsEnv string) (map[string][]string, error) {
 	result := make(map[string][]string)
 
@@ -300,7 +326,7 @@ func ParseNodeIPsFromEnv(nodeIPsEnv string) (map[string][]string, error) {
 		regions = strings.Split(nodeIPsEnv, ";")
 	} else {
 		// Space-separated format: use regex to find all "region:ip" patterns
-		// Pattern matches: word characters (region name), colon, then IP address(es) optionally separated by commas
+		// Pattern matches region/node keys, a colon, then IP address(es) optionally separated by commas.
 		// This handles formats like:
 		// - "us:1.2.3.4 nl:5.6.7.8"
 		// - "us 1.2.3.4 nl:5.6.7.8" (region name followed by space and IP)
@@ -308,7 +334,7 @@ func ParseNodeIPsFromEnv(nodeIPsEnv string) (map[string][]string, error) {
 
 		// First, try to find all patterns that match "region:ip" or "region:ip1,ip2"
 		// Pattern: one or more word chars, colon, then IP addresses (dots and numbers) possibly separated by commas
-		re := regexp.MustCompile(`\w+:\d+\.\d+\.\d+\.\d+(?:,\d+\.\d+\.\d+\.\d+)*`)
+		re := regexp.MustCompile(`[A-Za-z0-9_.-]+:\d+\.\d+\.\d+\.\d+(?:,\d+\.\d+\.\d+\.\d+)*`)
 		matches := re.FindAllString(nodeIPsEnv, -1)
 
 		if len(matches) > 0 {
@@ -317,7 +343,7 @@ func ParseNodeIPsFromEnv(nodeIPsEnv string) (map[string][]string, error) {
 		} else {
 			// Fallback: try to handle "region IP" format (region name followed by space and IP)
 			// Pattern: word chars (region), space, IP address
-			re2 := regexp.MustCompile(`(\w+)\s+(\d+\.\d+\.\d+\.\d+)`)
+			re2 := regexp.MustCompile(`([A-Za-z0-9_.-]+)\s+(\d+\.\d+\.\d+\.\d+)`)
 			matches2 := re2.FindAllStringSubmatch(nodeIPsEnv, -1)
 			for _, match := range matches2 {
 				if len(match) >= 3 {

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -93,19 +93,10 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 	var nodeRegion string
 
 	if err := DB.First(&node, "id = ?", nodeID).Error; err != nil {
-		// If node doesn't exist (e.g., was deleted), fall back to default region
+		// Older records may refer to a node that predates node metadata. Only use
+		// an unassigned compatibility fallback when it is unambiguous.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// Node not found - use fallback logic
-			if ips, ok := nodeIPMap["default"]; ok && len(ips) > 0 {
-				return ips, nil
-			}
-			// Try to find any region in the map as fallback
-			for region := range nodeIPMap {
-				if ips := nodeIPMap[region]; len(ips) > 0 {
-					return ips, nil
-				}
-			}
-			return nil, fmt.Errorf("node %s not found and no default node IP configured", nodeID)
+			return compatibilityNodeIPs(nodeIPMap, fmt.Sprintf("node %s not found", nodeID))
 		}
 		return nil, fmt.Errorf("failed to find node %s: %w", nodeID, err)
 	}
@@ -116,19 +107,9 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 
 	nodeRegion = node.Region
 
-	// If node has no region, try to find a default or return error
+	// If node has no region, only use an unambiguous compatibility fallback.
 	if nodeRegion == "" {
-		// Try to find "default" region first, then any region as fallback
-		if ips, ok := nodeIPMap["default"]; ok && len(ips) > 0 {
-			return ips, nil
-		}
-		// Try to find any region in the map as fallback
-		for region := range nodeIPMap {
-			if ips := nodeIPMap[region]; len(ips) > 0 {
-				return ips, nil
-			}
-		}
-		return nil, fmt.Errorf("node %s has no region configured and no default region found", nodeID)
+		return compatibilityNodeIPs(nodeIPMap, fmt.Sprintf("node %s has no IP or region", nodeID))
 	}
 
 	// Get node IPs for this region
@@ -142,6 +123,43 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 	}
 
 	return ips, nil
+}
+
+func compatibilityNodeIPs(nodeIPMap map[string][]string, reason string) ([]string, error) {
+	if ips := cleanNodeIPs(nodeIPMap["default"]); len(ips) > 0 {
+		return ips, nil
+	}
+
+	var onlyRegionIPs []string
+	regions := 0
+	for region, rawIPs := range nodeIPMap {
+		if region == "default" {
+			continue
+		}
+		ips := cleanNodeIPs(rawIPs)
+		if len(ips) == 0 {
+			continue
+		}
+		regions++
+		onlyRegionIPs = ips
+	}
+	if regions == 1 {
+		return onlyRegionIPs, nil
+	}
+	if regions > 1 {
+		return nil, fmt.Errorf("%s and NODE_IPS contains %d regions; refusing ambiguous cross-node DNS fallback", reason, regions)
+	}
+	return nil, fmt.Errorf("%s and no fallback node IP is configured", reason)
+}
+
+func cleanNodeIPs(rawIPs []string) []string {
+	ips := make([]string, 0, len(rawIPs))
+	for _, ip := range rawIPs {
+		if ip = strings.TrimSpace(ip); ip != "" {
+			ips = append(ips, ip)
+		}
+	}
+	return ips
 }
 
 // GetDatabaseNodeIP returns the node IPs for a managed database domain.
@@ -163,29 +181,24 @@ func GetDatabaseNodeIP(databaseID string, nodeIPMap map[string][]string) ([]stri
 		return nil, fmt.Errorf("failed to query database %s: %w", databaseID, err)
 	}
 
-	if dbInstance.NodeID != nil && *dbInstance.NodeID != "" {
-		var node NodeMetadata
-		if err := DB.First(&node, "id = ?", *dbInstance.NodeID).Error; err == nil {
-			nodeRegion := node.Region
-			if nodeRegion != "" {
-				if ips, ok := nodeIPMap[nodeRegion]; ok && len(ips) > 0 {
-					return ips, nil
-				}
-			}
-		}
+	var locations []DatabaseLocation
+	if err := DB.Where("database_id = ? AND status IN ?", databaseID, []string{"running", "restarting", "starting", "created"}).
+		Order("updated_at DESC").
+		Find(&locations).Error; err != nil {
+		return nil, fmt.Errorf("failed to query database locations: %w", err)
 	}
-
-	if ips, ok := nodeIPMap["default"]; ok && len(ips) > 0 {
-		return ips, nil
-	}
-
-	for _, ips := range nodeIPMap {
-		if len(ips) > 0 {
+	if len(locations) > 0 {
+		location := locations[0]
+		if ips, err := resolvePreferredNodeIPs(location.NodeID, location.NodeIP, nodeIPMap); err == nil {
 			return ips, nil
 		}
 	}
 
-	return nil, fmt.Errorf("no node IPs configured for database %s", databaseID)
+	if dbInstance.NodeID != nil && *dbInstance.NodeID != "" {
+		return resolvePreferredNodeIPs(*dbInstance.NodeID, "", nodeIPMap)
+	}
+
+	return compatibilityNodeIPs(nodeIPMap, fmt.Sprintf("database %s has no recorded host node", databaseID))
 }
 
 // GetDeploymentRegion returns the region where a deployment is running

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -204,9 +204,11 @@ func GetDatabaseNodeIP(databaseID string, nodeIPMap map[string][]string) ([]stri
 	}
 	if len(locations) > 0 {
 		location := locations[0]
-		if ips, err := resolvePreferredNodeIPs(location.NodeID, location.NodeIP, nodeIPMap); err == nil {
-			return ips, nil
+		ips, err := resolvePreferredNodeIPs(location.NodeID, location.NodeIP, nodeIPMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve active database location on node %s: %w", location.NodeID, err)
 		}
+		return ips, nil
 	}
 
 	if dbInstance.NodeID != nil && *dbInstance.NodeID != "" {

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -85,6 +85,14 @@ func GetGameServerNodeIP(gameServerID string, nodeIPMap map[string][]string) ([]
 }
 
 func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string) ([]string, error) {
+	return resolveNodeIPs(nodeID, explicitNodeIP, nodeIPMap, true)
+}
+
+func resolveAuthoritativeNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string) ([]string, error) {
+	return resolveNodeIPs(nodeID, explicitNodeIP, nodeIPMap, false)
+}
+
+func resolveNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string][]string, allowCompatibilityFallback bool) ([]string, error) {
 	if explicitNodeIP = strings.TrimSpace(explicitNodeIP); configuredNodeIP(explicitNodeIP, nodeIPMap) {
 		return []string{explicitNodeIP}, nil
 	}
@@ -93,9 +101,12 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 	var nodeRegion string
 
 	if err := DB.First(&node, "id = ?", nodeID).Error; err != nil {
-		// Older records may refer to a node that predates node metadata. Only use
-		// an unassigned compatibility fallback when it is unambiguous.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if !allowCompatibilityFallback {
+				return nil, fmt.Errorf("node %s not found and authoritative DNS fallback is disabled", nodeID)
+			}
+			// Older records may refer to a node that predates node metadata. Only use
+			// an unassigned compatibility fallback when it is unambiguous.
 			return compatibilityNodeIPs(nodeIPMap, fmt.Sprintf("node %s not found", nodeID))
 		}
 		return nil, fmt.Errorf("failed to find node %s: %w", nodeID, err)
@@ -107,17 +118,24 @@ func resolvePreferredNodeIPs(nodeID, explicitNodeIP string, nodeIPMap map[string
 
 	nodeRegion = node.Region
 
-	// If node has no region, only use an unambiguous compatibility fallback.
 	if nodeRegion == "" {
+		if !allowCompatibilityFallback {
+			return nil, fmt.Errorf("node %s has no configured IP or region and authoritative DNS fallback is disabled", nodeID)
+		}
+		// If node has no region, only use an unambiguous compatibility fallback.
 		return compatibilityNodeIPs(nodeIPMap, fmt.Sprintf("node %s has no IP or region", nodeID))
 	}
 
 	// Get node IPs for this region
 	ips, ok := nodeIPMap[nodeRegion]
 	if !ok || len(ips) == 0 {
-		// Fallback to "default" region if the node's region doesn't exist
-		if defaultIPs, defaultOk := nodeIPMap["default"]; defaultOk && len(defaultIPs) > 0 {
-			return defaultIPs, nil
+		// Compatibility callers may use the historical default region. An
+		// authoritative database owner must never be replaced by another node.
+		if allowCompatibilityFallback {
+			defaultIPs := cleanNodeIPs(nodeIPMap["default"])
+			if len(defaultIPs) > 0 {
+				return defaultIPs, nil
+			}
 		}
 		return nil, fmt.Errorf("no node IP configured for region: %s", nodeRegion)
 	}
@@ -204,7 +222,7 @@ func GetDatabaseNodeIP(databaseID string, nodeIPMap map[string][]string) ([]stri
 	}
 	if len(locations) > 0 {
 		location := locations[0]
-		ips, err := resolvePreferredNodeIPs(location.NodeID, location.NodeIP, nodeIPMap)
+		ips, err := resolveAuthoritativeNodeIPs(location.NodeID, location.NodeIP, nodeIPMap)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve active database location on node %s: %w", location.NodeID, err)
 		}
@@ -212,7 +230,7 @@ func GetDatabaseNodeIP(databaseID string, nodeIPMap map[string][]string) ([]stri
 	}
 
 	if dbInstance.NodeID != nil && *dbInstance.NodeID != "" {
-		return resolvePreferredNodeIPs(*dbInstance.NodeID, "", nodeIPMap)
+		return resolveAuthoritativeNodeIPs(*dbInstance.NodeID, "", nodeIPMap)
 	}
 
 	return compatibilityNodeIPs(nodeIPMap, fmt.Sprintf("database %s has no recorded host node", databaseID))

--- a/apps/shared/pkg/database/dns.go
+++ b/apps/shared/pkg/database/dns.go
@@ -134,6 +134,11 @@ func resolveNodeIPs(nodeID, nodeHostname, explicitNodeIP string, nodeIPMap map[s
 
 	if nodeRegion == "" {
 		if !allowCompatibilityFallback {
+			if ips, found, err := soleNodeDefaultIPs(node, nodeIPMap); err != nil {
+				return nil, err
+			} else if found {
+				return ips, nil
+			}
 			return nil, fmt.Errorf("node %s has no configured IP or region and authoritative DNS fallback is disabled", nodeID)
 		}
 		// If node has no region, only use an unambiguous compatibility fallback.
@@ -158,6 +163,33 @@ func resolveNodeIPs(nodeID, nodeHostname, explicitNodeIP string, nodeIPMap map[s
 	}
 
 	return ips, nil
+}
+
+func soleNodeDefaultIPs(node NodeMetadata, nodeIPMap map[string][]string) ([]string, bool, error) {
+	defaultIPs := cleanNodeIPs(nodeIPMap["default"])
+	if len(defaultIPs) != 1 {
+		return nil, false, nil
+	}
+
+	nonEmptyMappings := 0
+	for _, rawIPs := range nodeIPMap {
+		if len(cleanNodeIPs(rawIPs)) > 0 {
+			nonEmptyMappings++
+		}
+	}
+	if nonEmptyMappings != 1 {
+		return nil, false, nil
+	}
+
+	var nodeCount int64
+	if err := DB.Model(&NodeMetadata{}).Count(&nodeCount).Error; err != nil {
+		return nil, false, fmt.Errorf("failed to determine whether node %s is the sole configured node: %w", node.ID, err)
+	}
+	if nodeCount != 1 {
+		return nil, false, nil
+	}
+
+	return defaultIPs, true, nil
 }
 
 func nodeSpecificIPs(node NodeMetadata, nodeIPMap map[string][]string) ([]string, bool, error) {

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -17,7 +17,7 @@ func TestGetDatabaseNodeIPPrefersRecordedHost(t *testing.T) {
 	if err := DB.Create(&DatabaseInstance{ID: databaseID, NodeID: &nodeID}).Error; err != nil {
 		t.Fatalf("create database instance: %v", err)
 	}
-	if err := DB.Create(&NodeMetadata{ID: nodeID, Hostname: "us-host", IP: "104.243.46.110"}).Error; err != nil {
+	if err := DB.Create(&NodeMetadata{ID: nodeID, Hostname: "us-host", IP: "192.0.2.10"}).Error; err != nil {
 		t.Fatalf("create node metadata: %v", err)
 	}
 
@@ -25,7 +25,7 @@ func TestGetDatabaseNodeIPPrefersRecordedHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve database node IP: %v", err)
 	}
-	assertNodeIPs(t, ips, "104.243.46.110")
+	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
 func TestGetDatabaseNodeIPPrefersCurrentLocation(t *testing.T) {
@@ -40,7 +40,7 @@ func TestGetDatabaseNodeIPPrefersCurrentLocation(t *testing.T) {
 		ID:          DatabaseLocationID(databaseID, "container-1"),
 		DatabaseID:  databaseID,
 		NodeID:      "node-us",
-		NodeIP:      "104.243.46.110",
+		NodeIP:      "192.0.2.10",
 		ContainerID: "container-1",
 		Status:      "running",
 		UpdatedAt:   time.Now(),
@@ -52,7 +52,7 @@ func TestGetDatabaseNodeIPPrefersCurrentLocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve database location IP: %v", err)
 	}
-	assertNodeIPs(t, ips, "104.243.46.110")
+	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
 func TestGetDatabaseNodeIPRejectsAmbiguousRegionFallback(t *testing.T) {
@@ -80,11 +80,11 @@ func TestGetDatabaseNodeIPAllowsSingleRegionCompatibilityFallback(t *testing.T) 
 		t.Fatalf("create database instance: %v", err)
 	}
 
-	ips, err := GetDatabaseNodeIP(databaseID, map[string][]string{"us-east": {"104.243.46.110"}})
+	ips, err := GetDatabaseNodeIP(databaseID, map[string][]string{"us-east": {"192.0.2.10"}})
 	if err != nil {
 		t.Fatalf("resolve legacy single-region database: %v", err)
 	}
-	assertNodeIPs(t, ips, "104.243.46.110")
+	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
 func TestResolvePreferredNodeIPsRejectsAmbiguousUnknownNode(t *testing.T) {
@@ -99,6 +99,25 @@ func TestResolvePreferredNodeIPsRejectsAmbiguousUnknownNode(t *testing.T) {
 	}
 }
 
+func TestResolvePreferredNodeIPsIgnoresUnconfiguredAdvertiseAddress(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	if err := DB.Create(&NodeMetadata{
+		ID:       "node-private",
+		Hostname: "private-host",
+		IP:       "203.0.113.55",
+		Region:   "us-east",
+	}).Error; err != nil {
+		t.Fatalf("create private node metadata: %v", err)
+	}
+
+	ips, err := resolvePreferredNodeIPs("node-private", "203.0.113.55", multiRegionNodeIPs())
+	if err != nil {
+		t.Fatalf("resolve configured public address: %v", err)
+	}
+	assertNodeIPs(t, ips, "192.0.2.10")
+}
+
 func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 
@@ -106,7 +125,7 @@ func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 		ID:          "legacy-location-id",
 		DatabaseID:  "db-upsert-test",
 		NodeID:      "node-nl",
-		NodeIP:      "175.110.112.242",
+		NodeIP:      "198.51.100.20",
 		ContainerID: "container-upsert",
 		Status:      "running",
 	}
@@ -118,7 +137,7 @@ func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 		ID:          DatabaseLocationID("db-upsert-test", "container-upsert"),
 		DatabaseID:  "db-upsert-test",
 		NodeID:      "node-us",
-		NodeIP:      "104.243.46.110",
+		NodeIP:      "192.0.2.10",
 		ContainerID: "container-upsert",
 		Status:      "running",
 	}
@@ -133,8 +152,35 @@ func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 	if len(locations) != 1 {
 		t.Fatalf("expected one location, got %d", len(locations))
 	}
-	if locations[0].ID != existing.ID || locations[0].NodeIP != "104.243.46.110" {
+	if locations[0].ID != existing.ID || locations[0].NodeIP != "192.0.2.10" {
 		t.Fatalf("unexpected reconciled location: %#v", locations[0])
+	}
+}
+
+func TestUpdateDatabaseLocationStatus(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	location := &DatabaseLocation{
+		ID:          "location-status-test",
+		DatabaseID:  "db-status-test",
+		NodeID:      "node-us",
+		ContainerID: "container-status-test",
+		Status:      "running",
+	}
+	if err := DB.Create(location).Error; err != nil {
+		t.Fatalf("create database location: %v", err)
+	}
+
+	if err := UpdateDatabaseLocationStatus(t.Context(), location.DatabaseID, "sleeping"); err != nil {
+		t.Fatalf("update database location status: %v", err)
+	}
+
+	var updated DatabaseLocation
+	if err := DB.First(&updated, "id = ?", location.ID).Error; err != nil {
+		t.Fatalf("load database location: %v", err)
+	}
+	if updated.Status != "sleeping" {
+		t.Fatalf("expected sleeping location status, got %q", updated.Status)
 	}
 }
 
@@ -154,8 +200,8 @@ func setupDNSRoutingTestDB(t *testing.T) {
 
 func multiRegionNodeIPs() map[string][]string {
 	return map[string][]string{
-		"us-east": {"104.243.46.110"},
-		"nl":      {"175.110.112.242"},
+		"us-east": {"192.0.2.10"},
+		"nl":      {"198.51.100.20"},
 	}
 }
 

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -147,6 +147,77 @@ func TestGetDatabaseNodeIPRejectsDefaultFallbackForActiveLocation(t *testing.T) 
 	}
 }
 
+func TestGetDatabaseNodeIPAllowsSingleDefaultAddressForSoleNode(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-single-node-default-test"
+	containerID := "container-single-node-default"
+	nodeID := "node-single-owner"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, InstanceID: &containerID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := DB.Create(&NodeMetadata{ID: nodeID, Hostname: "single-owner", IP: "203.0.113.55"}).Error; err != nil {
+		t.Fatalf("create node metadata: %v", err)
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:           DatabaseLocationID(databaseID, containerID),
+		DatabaseID:   databaseID,
+		NodeID:       nodeID,
+		NodeHostname: "single-owner",
+		NodeIP:       "203.0.113.55",
+		ContainerID:  containerID,
+		Status:       "running",
+		UpdatedAt:    time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create active database location: %v", err)
+	}
+
+	ips, err := GetDatabaseNodeIP(databaseID, map[string][]string{"default": {"192.0.2.10"}})
+	if err != nil {
+		t.Fatalf("resolve sole database owner from simple NODE_IPS mapping: %v", err)
+	}
+	assertNodeIPs(t, ips, "192.0.2.10")
+}
+
+func TestGetDatabaseNodeIPRejectsDefaultAddressWithMultipleNodes(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-multiple-node-default-test"
+	containerID := "container-multiple-node-default"
+	nodeID := "node-owner-a"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, InstanceID: &containerID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	for _, node := range []NodeMetadata{
+		{ID: nodeID, Hostname: "owner-a", IP: "203.0.113.55"},
+		{ID: "node-owner-b", Hostname: "owner-b", IP: "203.0.113.56"},
+	} {
+		if err := DB.Create(&node).Error; err != nil {
+			t.Fatalf("create node metadata: %v", err)
+		}
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:           DatabaseLocationID(databaseID, containerID),
+		DatabaseID:   databaseID,
+		NodeID:       nodeID,
+		NodeHostname: "owner-a",
+		NodeIP:       "203.0.113.55",
+		ContainerID:  containerID,
+		Status:       "running",
+		UpdatedAt:    time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create active database location: %v", err)
+	}
+
+	_, err := GetDatabaseNodeIP(databaseID, map[string][]string{"default": {"192.0.2.10"}})
+	if err == nil {
+		t.Fatal("expected simple NODE_IPS mapping to remain ambiguous with multiple nodes")
+	}
+	if !strings.Contains(err.Error(), "authoritative DNS fallback is disabled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGetDatabaseNodeIPRejectsAmbiguousRegionFallback(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -55,6 +55,33 @@ func TestGetDatabaseNodeIPPrefersCurrentLocation(t *testing.T) {
 	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
+func TestGetDatabaseNodeIPUsesSleepingLocationForWakeableDatabase(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-sleeping-location-test"
+	staleNodeID := "node-nl"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, NodeID: &staleNodeID, Status: 12}).Error; err != nil {
+		t.Fatalf("create sleeping database instance: %v", err)
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:          DatabaseLocationID(databaseID, "container-sleeping"),
+		DatabaseID:  databaseID,
+		NodeID:      "node-us",
+		NodeIP:      "192.0.2.10",
+		ContainerID: "container-sleeping",
+		Status:      "sleeping",
+		UpdatedAt:   time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create sleeping database location: %v", err)
+	}
+
+	ips, err := GetDatabaseNodeIP(databaseID, multiRegionNodeIPs())
+	if err != nil {
+		t.Fatalf("resolve sleeping database location IP: %v", err)
+	}
+	assertNodeIPs(t, ips, "192.0.2.10")
+}
+
 func TestGetDatabaseNodeIPDoesNotFallBackFromUnresolvedActiveLocation(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -192,11 +192,35 @@ func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 func TestUpdateDatabaseLocationStatus(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 
+	containerID := "container-status-test"
+	if err := DB.Create(&DatabaseInstance{ID: "db-status-test", InstanceID: &containerID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	historical := &DatabaseLocation{
+		ID:          "historical-location-status-test",
+		DatabaseID:  "db-status-test",
+		NodeID:      "node-old",
+		ContainerID: "container-old-status-test",
+		Status:      "running",
+	}
+	if err := DB.Create(historical).Error; err != nil {
+		t.Fatalf("create historical database location: %v", err)
+	}
+	if err := DB.Create(&DatabaseUptimeInterval{
+		ID:          "historical-interval-status-test",
+		DatabaseID:  historical.DatabaseID,
+		ContainerID: historical.ContainerID,
+		NodeID:      historical.NodeID,
+		StartedAt:   time.Now().Add(-time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("create historical uptime interval: %v", err)
+	}
+
 	location := &DatabaseLocation{
 		ID:          "location-status-test",
 		DatabaseID:  "db-status-test",
 		NodeID:      "node-us",
-		ContainerID: "container-status-test",
+		ContainerID: containerID,
 		Status:      "running",
 	}
 	if err := UpsertDatabaseLocation(location); err != nil {
@@ -230,8 +254,72 @@ func TestUpdateDatabaseLocationStatus(t *testing.T) {
 	if err := DB.Order("started_at").Find(&intervals, "database_id = ?", location.DatabaseID).Error; err != nil {
 		t.Fatalf("load uptime intervals: %v", err)
 	}
-	if len(intervals) != 2 || intervals[1].EndedAt != nil {
-		t.Fatalf("expected a closed interval followed by an open interval, got %#v", intervals)
+	if len(intervals) != 3 {
+		t.Fatalf("expected historical and current uptime intervals, got %#v", intervals)
+	}
+	var historicalAfter DatabaseLocation
+	if err := DB.First(&historicalAfter, "id = ?", historical.ID).Error; err != nil {
+		t.Fatalf("load historical location: %v", err)
+	}
+	if historicalAfter.Status != "stopped" {
+		t.Fatalf("expected historical location to remain stopped, got %q", historicalAfter.Status)
+	}
+	var openIntervals int64
+	if err := DB.Model(&DatabaseUptimeInterval{}).
+		Where("database_id = ? AND ended_at IS NULL", location.DatabaseID).
+		Count(&openIntervals).Error; err != nil {
+		t.Fatalf("count open uptime intervals: %v", err)
+	}
+	if openIntervals != 1 {
+		t.Fatalf("expected exactly one open interval for the current container, got %d", openIntervals)
+	}
+}
+
+func TestBackfillDatabaseUptimeIntervalsPreservesLegacyTimestamps(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	runningStart := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	stoppedStart := time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC)
+	stoppedEnd := time.Date(2026, time.May, 3, 0, 0, 0, 0, time.UTC)
+	locations := []DatabaseLocation{
+		{
+			ID:          "legacy-running-location",
+			DatabaseID:  "db-legacy-running",
+			NodeID:      "node-us",
+			ContainerID: "container-legacy-running",
+			Status:      "running",
+			CreatedAt:   runningStart,
+			UpdatedAt:   runningStart.Add(time.Hour),
+		},
+		{
+			ID:          "legacy-stopped-location",
+			DatabaseID:  "db-legacy-stopped",
+			NodeID:      "node-nl",
+			ContainerID: "container-legacy-stopped",
+			Status:      "stopped",
+			CreatedAt:   stoppedStart,
+			UpdatedAt:   stoppedEnd,
+		},
+	}
+	if err := DB.Create(&locations).Error; err != nil {
+		t.Fatalf("create legacy database locations: %v", err)
+	}
+	if err := BackfillDatabaseUptimeIntervals(); err != nil {
+		t.Fatalf("backfill database uptime intervals: %v", err)
+	}
+
+	var intervals []DatabaseUptimeInterval
+	if err := DB.Order("started_at").Find(&intervals).Error; err != nil {
+		t.Fatalf("load backfilled uptime intervals: %v", err)
+	}
+	if len(intervals) != 2 {
+		t.Fatalf("expected two backfilled intervals, got %d", len(intervals))
+	}
+	if !intervals[0].StartedAt.Equal(stoppedStart) || intervals[0].EndedAt == nil || !intervals[0].EndedAt.Equal(stoppedEnd) {
+		t.Fatalf("unexpected stopped legacy interval: %#v", intervals[0])
+	}
+	if !intervals[1].StartedAt.Equal(runningStart) || intervals[1].EndedAt != nil {
+		t.Fatalf("unexpected running legacy interval: %#v", intervals[1])
 	}
 }
 

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -87,6 +87,38 @@ func TestGetDatabaseNodeIPDoesNotFallBackFromUnresolvedActiveLocation(t *testing
 	}
 }
 
+func TestGetDatabaseNodeIPRejectsDefaultFallbackForActiveLocation(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-authoritative-default-test"
+	containerID := "container-authoritative-default"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, InstanceID: &containerID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:          DatabaseLocationID(databaseID, containerID),
+		DatabaseID:  databaseID,
+		NodeID:      "node-without-metadata",
+		NodeIP:      "203.0.113.55",
+		ContainerID: containerID,
+		Status:      "running",
+		UpdatedAt:   time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create active database location: %v", err)
+	}
+
+	_, err := GetDatabaseNodeIP(databaseID, map[string][]string{
+		"default": {"192.0.2.10"},
+		"eu-west": {"198.51.100.20"},
+	})
+	if err == nil {
+		t.Fatal("expected authoritative location to reject the default fallback")
+	}
+	if !strings.Contains(err.Error(), "authoritative DNS fallback is disabled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGetDatabaseNodeIPRejectsAmbiguousRegionFallback(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -231,6 +232,21 @@ func TestResolveAuthoritativeNodeIPsUsesNodeSpecificAddress(t *testing.T) {
 	assertNodeIPs(t, ips, "192.0.2.11")
 }
 
+func TestResolveAuthoritativeLocationUsesExactMappingWithoutMetadata(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	ips, err := resolveAuthoritativeLocationNodeIPs(
+		"node-without-metadata",
+		"owner-without-metadata",
+		"203.0.113.55",
+		map[string][]string{"owner-without-metadata": {"192.0.2.10"}},
+	)
+	if err != nil {
+		t.Fatalf("resolve exact owner mapping without node metadata: %v", err)
+	}
+	assertNodeIPs(t, ips, "192.0.2.10")
+}
+
 func TestResolveAuthoritativeNodeIPsRejectsAmbiguousRegion(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 
@@ -439,6 +455,53 @@ func TestUpdateDatabaseLocationStatus(t *testing.T) {
 	}
 	if openIntervals != 1 {
 		t.Fatalf("expected exactly one open interval for the current container, got %d", openIntervals)
+	}
+}
+
+func TestUpdateDatabaseRuntimeStatusRollsBackSplitTransition(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-atomic-runtime-status-test"
+	containerID := "container-atomic-runtime-status-test"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, InstanceID: &containerID, Status: 3}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := UpsertDatabaseLocation(&DatabaseLocation{
+		ID:          DatabaseLocationID(databaseID, containerID),
+		DatabaseID:  databaseID,
+		NodeID:      "node-atomic-runtime-status-test",
+		ContainerID: containerID,
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("create database location: %v", err)
+	}
+
+	callbackName := "test:fail-runtime-location-update"
+	if err := DB.Callback().Update().Before("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Table == "database_locations" {
+			tx.AddError(errors.New("synthetic location update failure"))
+		}
+	}); err != nil {
+		t.Fatalf("register failing update callback: %v", err)
+	}
+	t.Cleanup(func() { _ = DB.Callback().Update().Remove(callbackName) })
+
+	if err := UpdateDatabaseRuntimeStatus(t.Context(), databaseID, 5, "stopped"); err == nil {
+		t.Fatal("expected split runtime transition to fail")
+	}
+	var instance DatabaseInstance
+	if err := DB.First(&instance, "id = ?", databaseID).Error; err != nil {
+		t.Fatalf("load database instance: %v", err)
+	}
+	if instance.Status != 3 {
+		t.Fatalf("instance status committed without its location: %d", instance.Status)
+	}
+	var location DatabaseLocation
+	if err := DB.First(&location, "container_id = ?", containerID).Error; err != nil {
+		t.Fatalf("load database location: %v", err)
+	}
+	if location.Status != "running" {
+		t.Fatalf("location status changed despite rollback: %q", location.Status)
 	}
 }
 

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -1,0 +1,172 @@
+package database
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetDatabaseNodeIPPrefersRecordedHost(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	nodeID := "node-us"
+	databaseID := "db-routing-test"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, NodeID: &nodeID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := DB.Create(&NodeMetadata{ID: nodeID, Hostname: "us-host", IP: "104.243.46.110"}).Error; err != nil {
+		t.Fatalf("create node metadata: %v", err)
+	}
+
+	ips, err := GetDatabaseNodeIP(databaseID, multiRegionNodeIPs())
+	if err != nil {
+		t.Fatalf("resolve database node IP: %v", err)
+	}
+	assertNodeIPs(t, ips, "104.243.46.110")
+}
+
+func TestGetDatabaseNodeIPPrefersCurrentLocation(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-location-test"
+	oldNodeID := "node-nl"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, NodeID: &oldNodeID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:          DatabaseLocationID(databaseID, "container-1"),
+		DatabaseID:  databaseID,
+		NodeID:      "node-us",
+		NodeIP:      "104.243.46.110",
+		ContainerID: "container-1",
+		Status:      "running",
+		UpdatedAt:   time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create database location: %v", err)
+	}
+
+	ips, err := GetDatabaseNodeIP(databaseID, multiRegionNodeIPs())
+	if err != nil {
+		t.Fatalf("resolve database location IP: %v", err)
+	}
+	assertNodeIPs(t, ips, "104.243.46.110")
+}
+
+func TestGetDatabaseNodeIPRejectsAmbiguousRegionFallback(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-unassigned-test"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+
+	_, err := GetDatabaseNodeIP(databaseID, multiRegionNodeIPs())
+	if err == nil {
+		t.Fatal("expected unassigned multi-region database resolution to fail")
+	}
+	if !strings.Contains(err.Error(), "refusing ambiguous cross-node DNS fallback") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetDatabaseNodeIPAllowsSingleRegionCompatibilityFallback(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-legacy-test"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+
+	ips, err := GetDatabaseNodeIP(databaseID, map[string][]string{"us-east": {"104.243.46.110"}})
+	if err != nil {
+		t.Fatalf("resolve legacy single-region database: %v", err)
+	}
+	assertNodeIPs(t, ips, "104.243.46.110")
+}
+
+func TestResolvePreferredNodeIPsRejectsAmbiguousUnknownNode(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	_, err := resolvePreferredNodeIPs("missing-node", "", multiRegionNodeIPs())
+	if err == nil {
+		t.Fatal("expected unknown node with multi-region fallback to fail")
+	}
+	if !strings.Contains(err.Error(), "refusing ambiguous cross-node DNS fallback") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	existing := &DatabaseLocation{
+		ID:          "legacy-location-id",
+		DatabaseID:  "db-upsert-test",
+		NodeID:      "node-nl",
+		NodeIP:      "175.110.112.242",
+		ContainerID: "container-upsert",
+		Status:      "running",
+	}
+	if err := DB.Create(existing).Error; err != nil {
+		t.Fatalf("create existing database location: %v", err)
+	}
+
+	updated := &DatabaseLocation{
+		ID:          DatabaseLocationID("db-upsert-test", "container-upsert"),
+		DatabaseID:  "db-upsert-test",
+		NodeID:      "node-us",
+		NodeIP:      "104.243.46.110",
+		ContainerID: "container-upsert",
+		Status:      "running",
+	}
+	if err := UpsertDatabaseLocation(updated); err != nil {
+		t.Fatalf("upsert database location: %v", err)
+	}
+
+	var locations []DatabaseLocation
+	if err := DB.Find(&locations).Error; err != nil {
+		t.Fatalf("query database locations: %v", err)
+	}
+	if len(locations) != 1 {
+		t.Fatalf("expected one location, got %d", len(locations))
+	}
+	if locations[0].ID != existing.ID || locations[0].NodeIP != "104.243.46.110" {
+		t.Fatalf("unexpected reconciled location: %#v", locations[0])
+	}
+}
+
+func setupDNSRoutingTestDB(t *testing.T) {
+	t.Helper()
+	previousDB := DB
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&DatabaseInstance{}, &DatabaseLocation{}, &NodeMetadata{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	DB = db
+	t.Cleanup(func() { DB = previousDB })
+}
+
+func multiRegionNodeIPs() map[string][]string {
+	return map[string][]string{
+		"us-east": {"104.243.46.110"},
+		"nl":      {"175.110.112.242"},
+	}
+}
+
+func assertNodeIPs(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -339,6 +339,9 @@ func TestBackfillDatabaseUptimeIntervalsPreservesLegacyTimestamps(t *testing.T) 
 	if err := BackfillDatabaseUptimeIntervals(); err != nil {
 		t.Fatalf("backfill database uptime intervals: %v", err)
 	}
+	if err := BackfillDatabaseUptimeIntervals(); err != nil {
+		t.Fatalf("rerun database uptime backfill: %v", err)
+	}
 
 	var intervals []DatabaseUptimeInterval
 	if err := DB.Order("started_at").Find(&intervals).Error; err != nil {

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -209,6 +209,60 @@ func TestResolvePreferredNodeIPsIgnoresUnconfiguredAdvertiseAddress(t *testing.T
 	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
+func TestResolveAuthoritativeNodeIPsUsesNodeSpecificAddress(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	if err := DB.Create(&NodeMetadata{
+		ID:       "node-owner",
+		Hostname: "owner-host",
+		IP:       "203.0.113.55",
+		Region:   "us-east",
+	}).Error; err != nil {
+		t.Fatalf("create owner node metadata: %v", err)
+	}
+
+	ips, err := resolveAuthoritativeNodeIPs("node-owner", "203.0.113.55", map[string][]string{
+		"node-owner": {"192.0.2.11"},
+		"us-east":    {"192.0.2.10", "192.0.2.11"},
+	})
+	if err != nil {
+		t.Fatalf("resolve node-specific owner address: %v", err)
+	}
+	assertNodeIPs(t, ips, "192.0.2.11")
+}
+
+func TestResolveAuthoritativeNodeIPsRejectsAmbiguousRegion(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	if err := DB.Create(&NodeMetadata{
+		ID:       "node-owner",
+		Hostname: "owner-host",
+		IP:       "203.0.113.55",
+		Region:   "us-east",
+	}).Error; err != nil {
+		t.Fatalf("create owner node metadata: %v", err)
+	}
+
+	_, err := resolveAuthoritativeNodeIPs("node-owner", "203.0.113.55", map[string][]string{
+		"us-east": {"192.0.2.10", "192.0.2.11"},
+	})
+	if err == nil {
+		t.Fatal("expected an ambiguous regional owner mapping to fail")
+	}
+	if !strings.Contains(err.Error(), "configure exactly one NODE_IPS entry for node node-owner") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseNodeIPsFromEnvPreservesNodeHostnameKeys(t *testing.T) {
+	nodeIPs, err := ParseNodeIPsFromEnv("owner-node:192.0.2.10 backup.node:198.51.100.20")
+	if err != nil {
+		t.Fatalf("parse node-specific IP mappings: %v", err)
+	}
+	assertNodeIPs(t, nodeIPs["owner-node"], "192.0.2.10")
+	assertNodeIPs(t, nodeIPs["backup.node"], "198.51.100.20")
+}
+
 func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 
@@ -246,6 +300,60 @@ func TestUpsertDatabaseLocationPreservesExistingPrimaryKey(t *testing.T) {
 	if locations[0].ID != existing.ID || locations[0].NodeIP != "192.0.2.10" {
 		t.Fatalf("unexpected reconciled location: %#v", locations[0])
 	}
+}
+
+func TestUpsertDatabaseLocationDeactivatesSupersededSleepingOwner(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-superseded-sleeping-owner-test"
+	currentContainerID := "container-current-owner"
+	currentNodeID := "node-current-owner"
+	if err := DB.Create(&DatabaseInstance{
+		ID:         databaseID,
+		InstanceID: &currentContainerID,
+		NodeID:     &currentNodeID,
+	}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := DB.Create(&NodeMetadata{ID: currentNodeID, Hostname: "current-owner", IP: "192.0.2.10"}).Error; err != nil {
+		t.Fatalf("create current owner metadata: %v", err)
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:          "superseded-sleeping-location",
+		DatabaseID:  databaseID,
+		NodeID:      "node-old-owner",
+		NodeIP:      "198.51.100.20",
+		ContainerID: "container-old-owner",
+		Status:      "sleeping",
+	}).Error; err != nil {
+		t.Fatalf("create superseded sleeping location: %v", err)
+	}
+	if err := UpsertDatabaseLocation(&DatabaseLocation{
+		ID:          DatabaseLocationID(databaseID, currentContainerID),
+		DatabaseID:  databaseID,
+		NodeID:      currentNodeID,
+		NodeIP:      "192.0.2.10",
+		ContainerID: currentContainerID,
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("upsert current database location: %v", err)
+	}
+	if err := UpdateDatabaseLocationStatus(t.Context(), databaseID, "stopped"); err != nil {
+		t.Fatalf("stop current database location: %v", err)
+	}
+
+	var oldLocation DatabaseLocation
+	if err := DB.First(&oldLocation, "id = ?", "superseded-sleeping-location").Error; err != nil {
+		t.Fatalf("load superseded sleeping location: %v", err)
+	}
+	if oldLocation.Status != "stopped" {
+		t.Fatalf("expected superseded sleeping location to be stopped, got %q", oldLocation.Status)
+	}
+	ips, err := GetDatabaseNodeIP(databaseID, multiRegionNodeIPs())
+	if err != nil {
+		t.Fatalf("resolve current database owner: %v", err)
+	}
+	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
 func TestUpdateDatabaseLocationStatus(t *testing.T) {

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -55,6 +55,38 @@ func TestGetDatabaseNodeIPPrefersCurrentLocation(t *testing.T) {
 	assertNodeIPs(t, ips, "192.0.2.10")
 }
 
+func TestGetDatabaseNodeIPDoesNotFallBackFromUnresolvedActiveLocation(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-authoritative-location-test"
+	staleNodeID := "node-nl"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, NodeID: &staleNodeID}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	if err := DB.Create(&NodeMetadata{ID: staleNodeID, Hostname: "nl-host", Region: "nl"}).Error; err != nil {
+		t.Fatalf("create stale node metadata: %v", err)
+	}
+	if err := DB.Create(&DatabaseLocation{
+		ID:          DatabaseLocationID(databaseID, "container-authoritative"),
+		DatabaseID:  databaseID,
+		NodeID:      "node-current",
+		NodeIP:      "203.0.113.55",
+		ContainerID: "container-authoritative",
+		Status:      "running",
+		UpdatedAt:   time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create active database location: %v", err)
+	}
+
+	_, err := GetDatabaseNodeIP(databaseID, multiRegionNodeIPs())
+	if err == nil {
+		t.Fatal("expected unresolved active location to remain authoritative")
+	}
+	if !strings.Contains(err.Error(), "failed to resolve active database location") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGetDatabaseNodeIPRejectsAmbiguousRegionFallback(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 
@@ -167,7 +199,7 @@ func TestUpdateDatabaseLocationStatus(t *testing.T) {
 		ContainerID: "container-status-test",
 		Status:      "running",
 	}
-	if err := DB.Create(location).Error; err != nil {
+	if err := UpsertDatabaseLocation(location); err != nil {
 		t.Fatalf("create database location: %v", err)
 	}
 
@@ -182,6 +214,25 @@ func TestUpdateDatabaseLocationStatus(t *testing.T) {
 	if updated.Status != "sleeping" {
 		t.Fatalf("expected sleeping location status, got %q", updated.Status)
 	}
+
+	var firstInterval DatabaseUptimeInterval
+	if err := DB.First(&firstInterval, "database_id = ?", location.DatabaseID).Error; err != nil {
+		t.Fatalf("load closed uptime interval: %v", err)
+	}
+	if firstInterval.EndedAt == nil {
+		t.Fatal("expected sleeping transition to close the running interval")
+	}
+
+	if err := UpdateDatabaseLocationStatus(t.Context(), location.DatabaseID, "running"); err != nil {
+		t.Fatalf("restart database location: %v", err)
+	}
+	var intervals []DatabaseUptimeInterval
+	if err := DB.Order("started_at").Find(&intervals, "database_id = ?", location.DatabaseID).Error; err != nil {
+		t.Fatalf("load uptime intervals: %v", err)
+	}
+	if len(intervals) != 2 || intervals[1].EndedAt != nil {
+		t.Fatalf("expected a closed interval followed by an open interval, got %#v", intervals)
+	}
 }
 
 func setupDNSRoutingTestDB(t *testing.T) {
@@ -191,7 +242,7 @@ func setupDNSRoutingTestDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open test database: %v", err)
 	}
-	if err := db.AutoMigrate(&DatabaseInstance{}, &DatabaseLocation{}, &NodeMetadata{}); err != nil {
+	if err := db.AutoMigrate(&DatabaseInstance{}, &DatabaseLocation{}, &DatabaseUptimeInterval{}, &NodeMetadata{}); err != nil {
 		t.Fatalf("migrate test database: %v", err)
 	}
 	DB = db

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -385,6 +385,44 @@ func TestBackfillDatabaseUptimeIntervalsPreservesLegacyTimestamps(t *testing.T) 
 	}
 }
 
+func TestDatabaseUptimeIntervalAllowsOnlyOneOpenRowPerContainer(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	location := &DatabaseLocation{
+		DatabaseID:  "db-atomic-uptime-test",
+		ContainerID: "container-atomic-uptime-test",
+		NodeID:      "node-us",
+	}
+	now := time.Date(2026, time.June, 10, 12, 0, 0, 0, time.UTC)
+	if err := ensureDatabaseUptimeInterval(DB, location, now); err != nil {
+		t.Fatalf("create first uptime interval: %v", err)
+	}
+	if err := ensureDatabaseUptimeInterval(DB, location, now.Add(time.Second)); err != nil {
+		t.Fatalf("ignore duplicate uptime interval: %v", err)
+	}
+
+	var openIntervals int64
+	if err := DB.Model(&DatabaseUptimeInterval{}).
+		Where("database_id = ? AND container_id = ? AND ended_at IS NULL", location.DatabaseID, location.ContainerID).
+		Count(&openIntervals).Error; err != nil {
+		t.Fatalf("count open uptime intervals: %v", err)
+	}
+	if openIntervals != 1 {
+		t.Fatalf("expected one open uptime interval, got %d", openIntervals)
+	}
+
+	duplicate := DatabaseUptimeInterval{
+		ID:          "duplicate-open-interval",
+		DatabaseID:  location.DatabaseID,
+		ContainerID: location.ContainerID,
+		NodeID:      location.NodeID,
+		StartedAt:   now.Add(2 * time.Second),
+	}
+	if err := DB.Create(&duplicate).Error; err == nil {
+		t.Fatal("expected the database to reject a second open uptime interval")
+	}
+}
+
 func setupDNSRoutingTestDB(t *testing.T) {
 	t.Helper()
 	previousDB := DB

--- a/apps/shared/pkg/database/dns_routing_test.go
+++ b/apps/shared/pkg/database/dns_routing_test.go
@@ -556,6 +556,58 @@ func TestBackfillDatabaseUptimeIntervalsPreservesLegacyTimestamps(t *testing.T) 
 	}
 }
 
+func TestBackfillDatabaseUptimeIntervalsClosesSupersededRunningLocation(t *testing.T) {
+	setupDNSRoutingTestDB(t)
+
+	databaseID := "db-legacy-multiple-running-test"
+	currentContainerID := "container-legacy-current"
+	if err := DB.Create(&DatabaseInstance{ID: databaseID, InstanceID: &currentContainerID, Status: 3}).Error; err != nil {
+		t.Fatalf("create database instance: %v", err)
+	}
+	oldUpdatedAt := time.Date(2026, time.May, 2, 0, 0, 0, 0, time.UTC)
+	locations := []DatabaseLocation{
+		{
+			ID:          "legacy-superseded-running-location",
+			DatabaseID:  databaseID,
+			NodeID:      "node-legacy-old",
+			ContainerID: "container-legacy-old",
+			Status:      "running",
+			CreatedAt:   oldUpdatedAt.Add(-time.Hour),
+			UpdatedAt:   oldUpdatedAt,
+		},
+		{
+			ID:          "legacy-current-running-location",
+			DatabaseID:  databaseID,
+			NodeID:      "node-legacy-current",
+			ContainerID: currentContainerID,
+			Status:      "running",
+			CreatedAt:   oldUpdatedAt.Add(time.Hour),
+			UpdatedAt:   oldUpdatedAt.Add(2 * time.Hour),
+		},
+	}
+	if err := DB.Create(&locations).Error; err != nil {
+		t.Fatalf("create legacy running locations: %v", err)
+	}
+	if err := BackfillDatabaseUptimeIntervals(); err != nil {
+		t.Fatalf("backfill database uptime intervals: %v", err)
+	}
+
+	var openIntervals []DatabaseUptimeInterval
+	if err := DB.Where("database_id = ? AND ended_at IS NULL", databaseID).Find(&openIntervals).Error; err != nil {
+		t.Fatalf("load open uptime intervals: %v", err)
+	}
+	if len(openIntervals) != 1 || openIntervals[0].ContainerID != currentContainerID {
+		t.Fatalf("unexpected authoritative open intervals: %#v", openIntervals)
+	}
+	var superseded DatabaseLocation
+	if err := DB.First(&superseded, "id = ?", locations[0].ID).Error; err != nil {
+		t.Fatalf("load superseded database location: %v", err)
+	}
+	if superseded.Status != "stopped" {
+		t.Fatalf("superseded location status = %q, want stopped", superseded.Status)
+	}
+}
+
 func TestDatabaseUptimeIntervalAllowsOnlyOneOpenRowPerContainer(t *testing.T) {
 	setupDNSRoutingTestDB(t)
 

--- a/apps/shared/pkg/database/models.go
+++ b/apps/shared/pkg/database/models.go
@@ -1170,6 +1170,7 @@ type DatabaseConnection struct {
 	Password       string    `gorm:"column:password" json:"-"` // Encrypted password, never returned in JSON
 	Host           string    `gorm:"column:host" json:"host"`
 	Port           int32     `gorm:"column:port" json:"port"`
+	ProxyPort      int32     `gorm:"column:proxy_port;default:0" json:"proxy_port"`
 	SSLRequired    bool      `gorm:"column:ssl_required;default:true" json:"ssl_required"`
 	SSLCertificate *string   `gorm:"column:ssl_certificate;type:text" json:"ssl_certificate"`
 	CreatedAt      time.Time `gorm:"column:created_at" json:"created_at"`

--- a/apps/shared/pkg/docker/client.go
+++ b/apps/shared/pkg/docker/client.go
@@ -767,9 +767,9 @@ func (c *Client) ContainerInspect(ctx context.Context, containerID string) (cont
 	return result.Container, nil
 }
 
-// ManagedDatabaseContainerStates returns the running state of every managed
-// database container owned by this Docker daemon in one API call.
-func (c *Client) ManagedDatabaseContainerStates(ctx context.Context) (map[string]bool, error) {
+// ManagedDatabaseContainerStates returns the Docker runtime state of every
+// managed database container owned by this daemon in one API call.
+func (c *Client) ManagedDatabaseContainerStates(ctx context.Context) (map[string]string, error) {
 	if c == nil || c.api == nil {
 		return nil, ErrUninitialized
 	}
@@ -784,9 +784,9 @@ func (c *Client) ManagedDatabaseContainerStates(ctx context.Context) (map[string
 		return nil, fmt.Errorf("docker: list managed database containers: %w", err)
 	}
 
-	states := make(map[string]bool, len(result.Items))
+	states := make(map[string]string, len(result.Items))
 	for _, item := range result.Items {
-		states[item.ID] = item.State == "running"
+		states[item.ID] = strings.ToLower(strings.TrimSpace(string(item.State)))
 	}
 	return states, nil
 }

--- a/apps/shared/pkg/docker/client.go
+++ b/apps/shared/pkg/docker/client.go
@@ -31,6 +31,13 @@ type Client struct {
 	api client.APIClient
 }
 
+// NodeIdentity identifies the Docker node that owns locally managed resources.
+type NodeIdentity struct {
+	ID       string
+	Hostname string
+	IP       string
+}
+
 // New constructs a Docker client using environment variables and API version
 // negotiation so it works across Docker Desktop and remote engines.
 func New() (*Client, error) {
@@ -51,6 +58,34 @@ func (c *Client) Close() error {
 		return nil
 	}
 	return c.api.Close()
+}
+
+// CurrentNodeIdentity returns the identity of the Docker daemon backing this
+// client. In Swarm mode the stable Swarm node ID is used; standalone daemons
+// use the same local-<hostname> convention as the orchestrator node registry.
+func (c *Client) CurrentNodeIdentity(ctx context.Context) (NodeIdentity, error) {
+	if c == nil || c.api == nil {
+		return NodeIdentity{}, ErrUninitialized
+	}
+
+	result, err := c.api.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return NodeIdentity{}, fmt.Errorf("docker: inspect daemon identity: %w", err)
+	}
+
+	identity := NodeIdentity{
+		ID:       strings.TrimSpace(result.Info.Swarm.NodeID),
+		Hostname: strings.TrimSpace(result.Info.Name),
+		IP:       strings.TrimSpace(result.Info.Swarm.NodeAddr),
+	}
+	if identity.ID == "" {
+		identity.ID = "local-" + identity.Hostname
+	}
+	if identity.ID == "local-" {
+		return NodeIdentity{}, fmt.Errorf("docker: daemon hostname is empty")
+	}
+
+	return identity, nil
 }
 
 // ContainerConfig represents configuration for creating a container

--- a/apps/shared/pkg/docker/client.go
+++ b/apps/shared/pkg/docker/client.go
@@ -767,6 +767,30 @@ func (c *Client) ContainerInspect(ctx context.Context, containerID string) (cont
 	return result.Container, nil
 }
 
+// ManagedDatabaseContainerStates returns the running state of every managed
+// database container owned by this Docker daemon in one API call.
+func (c *Client) ManagedDatabaseContainerStates(ctx context.Context) (map[string]bool, error) {
+	if c == nil || c.api == nil {
+		return nil, ErrUninitialized
+	}
+
+	filters := make(client.Filters)
+	filters.Add("label", "cloud.obiente.service=database")
+	result, err := c.api.ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: filters,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("docker: list managed database containers: %w", err)
+	}
+
+	states := make(map[string]bool, len(result.Items))
+	for _, item := range result.Items {
+		states[item.ID] = item.State == "running"
+	}
+	return states, nil
+}
+
 // NetworkConnect connects a container to a network
 func (c *Client) NetworkConnect(ctx context.Context, networkName, containerID string) error {
 	if c == nil || c.api == nil {

--- a/apps/shared/pkg/docker/client.go
+++ b/apps/shared/pkg/docker/client.go
@@ -19,6 +19,8 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+
+	"github.com/obiente/cloud/apps/shared/pkg/utils"
 )
 
 // ErrUninitialized is returned when a client method is invoked before the
@@ -74,9 +76,11 @@ func (c *Client) CurrentNodeIdentity(ctx context.Context) (NodeIdentity, error) 
 	}
 
 	identity := NodeIdentity{
-		ID:       strings.TrimSpace(result.Info.Swarm.NodeID),
 		Hostname: strings.TrimSpace(result.Info.Name),
 		IP:       strings.TrimSpace(result.Info.Swarm.NodeAddr),
+	}
+	if utils.IsSwarmModeEnabled() {
+		identity.ID = strings.TrimSpace(result.Info.Swarm.NodeID)
 	}
 	if identity.ID == "" {
 		identity.ID = "local-" + identity.Hostname

--- a/apps/shared/pkg/orchestrator/node_selector.go
+++ b/apps/shared/pkg/orchestrator/node_selector.go
@@ -183,7 +183,7 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 				// Successfully got nodes - sync them
 				// Track all Swarm node IDs to identify nodes that should be removed
 				swarmNodeIDs := make(map[string]bool)
-				
+
 				for _, node := range nodesResult.Items {
 					// Get node info
 					nodeInfoResult, err := ns.dockerClient.NodeInspect(ctx, node.ID, client.NodeInspectOptions{})
@@ -194,7 +194,8 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 
 					hostname := nodeInfo.Description.Hostname
 					nodeID := node.ID
-					
+					nodeIP := strings.TrimSpace(nodeInfo.Status.Addr)
+
 					// Track this node ID as existing in Swarm
 					swarmNodeIDs[nodeID] = true
 
@@ -219,6 +220,10 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 							labelsJSON = string(labelsBytes)
 						}
 					}
+					nodeRegion := strings.TrimSpace(node.Spec.Annotations.Labels["region"])
+					if nodeRegion == "" && hostnameExists {
+						nodeRegion = existingNode.Region
+					}
 
 					var metadata *database.NodeMetadata
 					if hostnameExists && existingNode.ID != nodeID {
@@ -230,6 +235,8 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 						// Update the existing node's ID and other fields
 						existingNode.ID = nodeID
 						existingNode.Hostname = hostname
+						existingNode.IP = nodeIP
+						existingNode.Region = nodeRegion
 						existingNode.Role = string(node.Spec.Role)
 						existingNode.Availability = string(node.Spec.Availability)
 						existingNode.Status = string(node.Status.State)
@@ -253,6 +260,7 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 						metadata = &database.NodeMetadata{
 							ID:              nodeID,
 							Hostname:        hostname,
+							IP:              nodeIP,
 							Role:            string(node.Spec.Role),
 							Availability:    string(node.Spec.Availability),
 							Status:          string(node.Status.State),
@@ -263,6 +271,7 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 							DeploymentCount: deploymentCount,
 							MaxDeployments:  ns.maxDeploymentsPerNode,
 							Labels:          labelsJSON,
+							Region:          nodeRegion,
 						}
 					}
 
@@ -272,7 +281,7 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 					// Also update metrics separately to ensure last_heartbeat is updated
 					database.UpdateNodeMetrics(nodeID, usedCPU, usedMemory)
 				}
-				
+
 				// Clean up nodes that are no longer in the Swarm
 				// Only remove Swarm nodes (those that don't start with "local-")
 				var allDBNodes []database.NodeMetadata
@@ -289,7 +298,7 @@ func (ns *NodeSelector) syncNodeMetadata(ctx context.Context) error {
 						}
 					}
 				}
-				
+
 				// Successfully synced all nodes, return
 				return nil
 			}
@@ -311,6 +320,7 @@ func (ns *NodeSelector) registerLocalNode(ctx context.Context, info interface{})
 	// Get Swarm field
 	swarmField := v.FieldByName("Swarm")
 	var swarmNodeID string
+	var nodeIP string
 	var controlAvailable bool
 	if swarmField.IsValid() {
 		if nodeIDField := swarmField.FieldByName("NodeID"); nodeIDField.IsValid() {
@@ -318,6 +328,9 @@ func (ns *NodeSelector) registerLocalNode(ctx context.Context, info interface{})
 		}
 		if controlField := swarmField.FieldByName("ControlAvailable"); controlField.IsValid() {
 			controlAvailable = controlField.Bool()
+		}
+		if nodeAddrField := swarmField.FieldByName("NodeAddr"); nodeAddrField.IsValid() {
+			nodeIP = strings.TrimSpace(nodeAddrField.String())
 		}
 	}
 
@@ -358,6 +371,9 @@ func (ns *NodeSelector) registerLocalNode(ctx context.Context, info interface{})
 			role = string(nodeInfo.Spec.Role)
 			availability = string(nodeInfo.Spec.Availability)
 			status = string(nodeInfo.Status.State)
+			if addr := strings.TrimSpace(nodeInfo.Status.Addr); addr != "" {
+				nodeIP = addr
+			}
 			log.Printf("[NodeSelector] Got role=%s, availability=%s, status=%s from Swarm for node %s", role, availability, status, swarmNodeID)
 		} else {
 			// Can't get node info (might be worker node) - infer from ControlAvailable
@@ -412,6 +428,9 @@ func (ns *NodeSelector) registerLocalNode(ctx context.Context, info interface{})
 
 		// Update the existing node's ID and other fields
 		existingNode.ID = nodeID
+		if nodeIP != "" {
+			existingNode.IP = nodeIP
+		}
 		existingNode.Role = role
 		existingNode.Availability = availability
 		existingNode.Status = status
@@ -439,6 +458,7 @@ func (ns *NodeSelector) registerLocalNode(ctx context.Context, info interface{})
 		metadata = &database.NodeMetadata{
 			ID:              nodeID,
 			Hostname:        name,
+			IP:              nodeIP,
 			Role:            role,
 			Availability:    availability,
 			Status:          status,
@@ -456,6 +476,9 @@ func (ns *NodeSelector) registerLocalNode(ctx context.Context, info interface{})
 	} else {
 		// Node exists with same hostname and ID - just update it
 		metadata = &existingNode
+		if nodeIP != "" {
+			metadata.IP = nodeIP
+		}
 		metadata.Role = role
 		metadata.Availability = availability
 		metadata.Status = status
@@ -608,11 +631,11 @@ func (ns *NodeSelector) calculateNodeResourceUsage(ctx context.Context, nodeID s
 		if statsJSON.PreCPUStats.SystemUsage > 0 && statsJSON.CPUStats.SystemUsage > statsJSON.PreCPUStats.SystemUsage {
 			cpuDelta := int64(statsJSON.CPUStats.CPUUsage.TotalUsage - statsJSON.PreCPUStats.CPUUsage.TotalUsage)
 			systemDelta := int64(statsJSON.CPUStats.SystemUsage - statsJSON.PreCPUStats.SystemUsage)
-			
+
 			// Validate deltas to prevent invalid calculations
 			// Minimum systemDelta: 1 millisecond (1,000,000 nanoseconds) to prevent division by tiny numbers
 			const minSystemDelta = 1_000_000 // 1ms in nanoseconds
-			
+
 			if systemDelta >= minSystemDelta && statsJSON.CPUStats.OnlineCPUs > 0 {
 				// Handle counter wraparound (uint64 overflow)
 				if cpuDelta < 0 {
@@ -621,7 +644,7 @@ func (ns *NodeSelector) calculateNodeResourceUsage(ctx context.Context, nodeID s
 					cpuUsage = 0.0
 				} else {
 					cpuUsage = (float64(cpuDelta) / float64(systemDelta)) * float64(statsJSON.CPUStats.OnlineCPUs) * 100.0
-					
+
 					// Validate the result is physically reasonable
 					maxReasonableCPU := float64(statsJSON.CPUStats.OnlineCPUs) * 100.0
 					if cpuUsage < 0 || cpuUsage > maxReasonableCPU {

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -489,10 +489,67 @@ services:
     environment:
       PORT: 3014
       ENABLE_SWARM: ${ENABLE_SWARM:-true}
+      DATABASES_SERVICE_MODE: control-plane
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis]
     deploy:
-      # Each node that can own a standalone database container must also expose
-      # the host-mode database proxy ports used by that container's DNS record.
+      mode: replicated
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+        order: start-first
+      restart_policy:
+        condition: on-failure
+        delay: 10s
+        max_attempts: 10
+        window: 60s
+      resources:
+        limits:
+          cpus: "1"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+      placement:
+        constraints:
+          # Keep all node-local provisioning/lifecycle calls on the same Docker
+          # daemon that owns managed database containers.
+          - node.labels.databases.enabled == true
+      labels:
+        - "cloud.obiente.service=databases-service"
+        - "cloud.obiente.traefik=true"
+        - "traefik.enable=true"
+        - "traefik.http.routers.databases-service.rule=Host(`databases-service.${DOMAIN:-localhost}`)"
+        - "traefik.http.routers.databases-service.entrypoints=web"
+        - "traefik.http.services.databases-service.loadbalancer.server.port=3014"
+        - "traefik.docker.network=obiente_obiente-network"  # Ensure Traefik targets the shared overlay network
+        - "traefik.http.routers.databases-service-secure.rule=Host(`databases-service.${DOMAIN:-localhost}`)"
+        - "traefik.http.routers.databases-service-secure.entrypoints=websecure"
+        - "traefik.http.routers.databases-service-secure.tls.certresolver=letsencrypt"
+        - "traefik.http.routers.databases-service-secure.service=databases-service"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3014/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+    dns_search: []
+    networks:
+      - obiente-network
+      - obiente-databases
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  # Global data-plane proxy. Every possible database owner node exposes the
+  # host-mode listeners used by owner-specific database DNS records.
+  databases-proxy:
+    image: ghcr.io/obiente/cloud-databases-service:latest
+    environment:
+      PORT: 3014
+      ENABLE_SWARM: ${ENABLE_SWARM:-true}
+      DATABASES_SERVICE_MODE: proxy
+      <<: [*common-database, *common-metrics-db, *common-auth, *common-redis]
+    deploy:
       mode: global
       update_config:
         parallelism: 1
@@ -511,17 +568,8 @@ services:
           cpus: "0.1"
           memory: 128M
       labels:
-        - "cloud.obiente.service=databases-service"
-        - "cloud.obiente.traefik=true"
-        - "traefik.enable=true"
-        - "traefik.http.routers.databases-service.rule=Host(`databases-service.${DOMAIN:-localhost}`)"
-        - "traefik.http.routers.databases-service.entrypoints=web"
-        - "traefik.http.services.databases-service.loadbalancer.server.port=3014"
-        - "traefik.docker.network=obiente_obiente-network"  # Ensure Traefik targets the shared overlay network
-        - "traefik.http.routers.databases-service-secure.rule=Host(`databases-service.${DOMAIN:-localhost}`)"
-        - "traefik.http.routers.databases-service-secure.entrypoints=websecure"
-        - "traefik.http.routers.databases-service-secure.tls.certresolver=letsencrypt"
-        - "traefik.http.routers.databases-service-secure.service=databases-service"
+        - "cloud.obiente.service=databases-proxy"
+        - "cloud.obiente.traefik=false"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:3014/health || exit 1"]
       interval: 30s

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -4,8 +4,9 @@
 
 
 
-# This file requires docker-compose.base.yml to be merged before use
-# Usage: cat docker-compose.base.yml docker-compose.swarm.yml | docker stack deploy -c - obiente
+# This file requires docker-compose.base.yml to be merged before use.
+# Use scripts/deploy-swarm.sh so required node ownership labels are preserved.
+# Usage: ./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 
 # Swarm-specific common environment variables
 # Override ENABLE_SWARM to default to true for Swarm deployments

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -491,12 +491,13 @@ services:
       ENABLE_SWARM: ${ENABLE_SWARM:-true}
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis]
     deploy:
-      mode: replicated
-      replicas: 1  # Single replica: proxy holds in-memory route state
+      # Each node that can own a standalone database container must also expose
+      # the host-mode database proxy ports used by that container's DNS record.
+      mode: global
       update_config:
         parallelism: 1
         delay: 10s
-        order: start-first
+        order: stop-first
       restart_policy:
         condition: on-failure
         delay: 10s

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -488,6 +488,7 @@ services:
     image: ghcr.io/obiente/cloud-databases-service:latest
     environment:
       PORT: 3014
+      ENABLE_SWARM: ${ENABLE_SWARM:-true}
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis]
     deploy:
       mode: replicated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,6 +272,7 @@ services:
       dockerfile: apps/databases-service/Dockerfile
     environment:
       PORT: 3014
+      ENABLE_SWARM: ${ENABLE_SWARM:-false}
       <<: [*common-database, *common-metrics-db, *common-auth, *common-redis]
     depends_on:
       postgres:

--- a/docs/deployment/dns-configuration.md
+++ b/docs/deployment/dns-configuration.md
@@ -51,7 +51,7 @@ Edit your `docker-compose.swarm.yml` or `docker-compose.swarm.ha.yml`:
 ### Step 3: Deploy
 
 ```bash
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 ## Common Configurations
@@ -212,4 +212,3 @@ sudo ss -tulpn | grep :53
 - In Docker Swarm, port 53 must be available on each node where DNS runs
 - DNS queries are load-balanced across all running DNS instances
 - DNS caches responses for 60 seconds to reduce database load
-

--- a/docs/deployment/dns-host-mode.md
+++ b/docs/deployment/dns-host-mode.md
@@ -71,7 +71,7 @@ DNS_REPLICAS=2  # Run DNS on 2 nodes (both must have dns.enabled=true label)
 ### 4. Deploy the Stack
 
 ```bash
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 ## Verification
@@ -144,4 +144,3 @@ dig @<dns-node-ip> deploy-123.my.obiente.cloud
    ```bash
    docker run --rm --network obiente_obiente-network alpine nslookup deploy-123.my.obiente.cloud
    ```
-

--- a/docs/deployment/dns.md
+++ b/docs/deployment/dns.md
@@ -10,13 +10,15 @@ The DNS server is integrated into the API service and runs alongside it. It quer
 
 ### Required
 
-- **`NODE_IPS`**: Node IPs per region
+- **`NODE_IPS`**: Public IPs keyed by region or exact Swarm node ID/hostname
   - **Multi-region format**: `"region1:ip1,ip2;region2:ip3,ip4"`
   - **Simple format**: `"ip1,ip2"` (defaults to "default" region)
   - **Examples**:
     - Simple: `NODE_IPS="1.2.3.4"` or `NODE_IPS="1.2.3.4,1.2.3.5"`
     - Multi-region: `NODE_IPS="us-east-1:1.2.3.4,1.2.3.5;eu-west-1:5.6.7.8,5.6.7.9"`
+    - Node-specific owner: `NODE_IPS="owner-node:192.0.2.10;us-east-1:192.0.2.10,192.0.2.11"`
   - Maps regions to node IP addresses
+  - Managed databases in multi-node regions require a single-IP entry keyed by their owner node ID or hostname
   - Used for DNS resolution of both deployments and game servers
   - Multiple IPs per region enable load balancing
   - If using simple format, deployments and game servers will use the "default" region

--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -199,7 +199,7 @@ docker node inspect <node-name-or-id> --pretty
 Deploy to the Swarm cluster:
 
 ```bash
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 Or use the deploy script (recommended):
@@ -370,7 +370,7 @@ To update after code changes:
 
 ```bash
 # Redeploy the stack
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 
 # Force immediate update
 docker service update --force obiente_api
@@ -525,7 +525,7 @@ docker cp $(docker ps -qf name=redis):/data/dump.rdb ./redis-backup.rdb
 Updates are zero-downtime by default:
 
 ```bash
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 ### Graceful Shutdown

--- a/docs/deployment/env-file.md
+++ b/docs/deployment/env-file.md
@@ -48,13 +48,13 @@ If you prefer to deploy manually:
 export $(cat .env | grep -v '^#' | xargs)
 
 # Deploy the stack
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 Or use a one-liner:
 
 ```bash
-set -a && source .env && set +a && docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 ## Environment Variable Loading
@@ -160,4 +160,3 @@ For multi-line values, use quotes:
 ```bash
 NODE_IPS="region1:ip1,ip2;region2:ip3,ip4"
 ```
-

--- a/docs/deployment/registry-auth.md
+++ b/docs/deployment/registry-auth.md
@@ -151,7 +151,7 @@ REGISTRY_USERNAME=obiente REGISTRY_PASSWORD=new-password ./scripts/setup-registr
    ```bash
    docker service update --env-add REGISTRY_PASSWORD=new-password obiente_api
    # Or redeploy the stack
-   docker stack deploy -c docker-compose.swarm.yml obiente
+   ./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
    ```
 3. **Re-authenticate on all Swarm nodes** (if needed):
    ```bash
@@ -239,4 +239,3 @@ If you see certificate errors:
 1. **Check Traefik logs**: `docker service logs obiente_traefik | grep -i certificate`
 2. **Verify domain is accessible**: Ensure `registry.yourdomain.com` resolves to your Traefik IP
 3. **Check Let's Encrypt rate limits**: If you've made many certificate requests, you may need to wait
-

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -22,7 +22,7 @@ docker compose up -d
 
 ```bash
 docker swarm init
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 See [Installation Guide](installation.md) for detailed instructions.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,7 +59,7 @@ For production environments:
 docker swarm init
 
 # Deploy the stack
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 
 # Check status
 docker service ls

--- a/docs/guides/vps-gateway-setup.md
+++ b/docs/guides/vps-gateway-setup.md
@@ -564,7 +564,7 @@ export GATEWAY_DHCP_INTERFACE=eth0  # Interface inside container (connected to O
 2. **Deploy Service**:
 
 ```bash
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 **Note**: For production, the gateway container should be deployed with `network_mode: host` or have direct access to the SDN bridge. You may need to deploy the service directly on the gateway container rather than in the Swarm cluster.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1492,7 +1492,7 @@ docker compose up
 
 ```bash
 # Load from .env file
-docker stack deploy --env-file .env -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 ## Security Best Practices

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -892,7 +892,7 @@ mode `0600`; the systemd installer copies it to `/etc/obiente`. See
 
 | Variable   | Type   | Default | Required | Description                                                                                                                                       |
 | ---------- | ------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NODE_IPS` | string | -       | ✅       | Node IPs per region (format: `"region1:ip1,ip2;region2:ip3,ip4"` or simple `"ip1,ip2"`). Used for DNS resolution of deployments and game servers. |
+| `NODE_IPS` | string | -       | ✅       | Public IPs keyed by region or exact Swarm node ID/hostname. Database owners in a multi-node region require a node-specific entry with one IP. |
 | `DNS_IPS`  | string | -       | ❌       | DNS server IPs (comma-separated) for nameserver configuration                                                                                     |
 | `DNS_PORT` | number | `53`    | ❌       | DNS server port (use different port if 53 is in use)                                                                                              |
 
@@ -983,7 +983,7 @@ Two formats are supported:
 ip1,ip2
 ```
 
-**Multi-region format**:
+**Keyed format** (keys may be regions, Swarm node IDs, or node hostnames):
 
 ```
 region1:ip1,ip2;region2:ip3,ip4
@@ -1004,9 +1004,17 @@ NODE_IPS="us-east-1:1.2.3.4,1.2.3.5"
 # Multiple regions
 NODE_IPS="us-east-1:1.2.3.4,1.2.3.5;eu-west-1:5.6.7.8,5.6.7.9"
 
+# Exact database owner plus its regional pool
+NODE_IPS="owner-node:192.0.2.10;us-east-1:192.0.2.10,192.0.2.11"
+
 # Explicit default region
 NODE_IPS="default:1.2.3.4"
 ```
+
+An authoritative managed-database record resolves to one owner node. When a
+region contains more than one address, configure a key matching that owner's
+Swarm node ID or hostname; otherwise the DNS service omits the ambiguous record
+instead of sending connections to a proxy without the database route.
 
 **DNS_IPS Format:**
 

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -48,7 +48,7 @@ For small deployments with basic redundancy:
 
 ```bash
 docker swarm init
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 See [Docker Swarm Deployment](../deployment/docker-swarm.md).
@@ -136,7 +136,7 @@ docker compose up -d
 Internal staging environment:
 
 ```bash
-docker stack deploy -c docker-compose.swarm.yml obiente
+./scripts/deploy-swarm.sh obiente docker-compose.swarm.yml
 ```
 
 ### Small Business

--- a/scripts/deploy-swarm.sh
+++ b/scripts/deploy-swarm.sh
@@ -213,7 +213,9 @@ echo "🚀 Deploying main stack '$STACK_NAME'..."
 
 # Preserve the Docker node that owns existing standalone database containers.
 # Fresh installations use the already designated PostgreSQL node.
-ensure_database_owner_label "$STACK_NAME"
+if database_owner_required "$COMPOSE_FILE"; then
+  ensure_database_owner_label "$STACK_NAME"
+fi
 
 # Note: We let Docker Swarm create the network automatically from the compose file
 # Pre-creating it manually causes conflicts. Docker Swarm will create it before services.

--- a/scripts/deploy-swarm.sh
+++ b/scripts/deploy-swarm.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
+# shellcheck source=scripts/lib/database-owner.sh
+source "${SCRIPT_DIR}/lib/database-owner.sh"
 
 TMP_FILES=()
 cleanup() {
@@ -208,6 +210,10 @@ fi
 
 echo ""
 echo "🚀 Deploying main stack '$STACK_NAME'..."
+
+# Preserve the Docker node that owns existing standalone database containers.
+# Fresh installations use the already designated PostgreSQL node.
+ensure_database_owner_label "$STACK_NAME"
 
 # Note: We let Docker Swarm create the network automatically from the compose file
 # Pre-creating it manually causes conflicts. Docker Swarm will create it before services.

--- a/scripts/force-deploy.sh
+++ b/scripts/force-deploy.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
+# shellcheck source=scripts/lib/database-owner.sh
+source "${SCRIPT_DIR}/lib/database-owner.sh"
 
 TMP_FILES=()
 cleanup() {
@@ -62,6 +64,11 @@ echo ""
 
 # Redeploy main stack
 echo -e "${BLUE}🚀 Redeploying main stack '${STACK_NAME}'...${NC}"
+
+# Preserve the Docker node that owns existing standalone database containers.
+if database_owner_required "$COMPOSE_FILE"; then
+  ensure_database_owner_label "$STACK_NAME"
+fi
 
 # Merge docker-compose.base.yml with the compose file
 # YAML anchors don't work across files, so we merge them first

--- a/scripts/lib/database-owner.sh
+++ b/scripts/lib/database-owner.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+database_owner_required() {
+  grep -q '^  databases-service:' "$1"
+}
+
 ensure_database_owner_label() {
   local stack_name="$1"
   local control_service="${stack_name}_databases-service"

--- a/scripts/lib/database-owner.sh
+++ b/scripts/lib/database-owner.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ensure_database_owner_label() {
+  local stack_name="$1"
+  local control_service="${stack_name}_databases-service"
+  local -a labeled_nodes=()
+  local -a postgres_nodes=()
+  local owner_node=""
+
+  mapfile -t labeled_nodes < <(docker node ls -q --filter node.label=databases.enabled=true | awk 'NF')
+  if [ "${#labeled_nodes[@]}" -gt 1 ]; then
+    echo "Error: multiple Swarm nodes have databases.enabled=true; exactly one control-plane owner is required." >&2
+    return 1
+  fi
+  if [ "${#labeled_nodes[@]}" -eq 1 ]; then
+    echo "Database control-plane owner label already exists on node ${labeled_nodes[0]}."
+    return 0
+  fi
+
+  if docker service inspect "$control_service" >/dev/null 2>&1; then
+    owner_node="$(docker service ps "$control_service" \
+      --filter desired-state=running \
+      --format '{{.Node}}' 2>/dev/null | awk 'NF { print; exit }')"
+  fi
+
+  if [ -z "$owner_node" ]; then
+    mapfile -t postgres_nodes < <(docker node ls -q --filter node.label=postgres.enabled=true | awk 'NF')
+    if [ "${#postgres_nodes[@]}" -ne 1 ]; then
+      echo "Error: cannot bootstrap the database owner; expected exactly one postgres.enabled=true node." >&2
+      return 1
+    fi
+    owner_node="${postgres_nodes[0]}"
+  fi
+
+  docker node update --label-add databases.enabled=true "$owner_node" >/dev/null
+  echo "Pinned the database control plane to its owner node ${owner_node}."
+}

--- a/scripts/tests/database-owner-test.sh
+++ b/scripts/tests/database-owner-test.sh
@@ -24,6 +24,13 @@ mock_bin="${TEST_DIR}/bin"
 mock_log="${TEST_DIR}/docker.log"
 mkdir -p "$mock_bin"
 
+printf 'services:\n  databases-service:\n' > "${TEST_DIR}/with-databases.yml"
+printf 'services:\n  api-gateway:\n' > "${TEST_DIR}/without-databases.yml"
+database_owner_required "${TEST_DIR}/with-databases.yml" || fail "database service was not detected"
+if database_owner_required "${TEST_DIR}/without-databases.yml"; then
+  fail "database owner was required for an unrelated stack"
+fi
+
 cat > "${mock_bin}/docker" <<'EOF'
 #!/usr/bin/env bash
 set -Eeuo pipefail
@@ -73,5 +80,12 @@ if PATH="${mock_bin}:${PATH}" \
   ensure_database_owner_label "test-stack"; then
   fail "multiple database owners were accepted"
 fi
+
+for deploy_script in deploy-swarm.sh force-deploy.sh; do
+  grep -Fq "source \"\${SCRIPT_DIR}/lib/database-owner.sh\"" "${TEST_SCRIPT_DIR}/${deploy_script}" ||
+    fail "${deploy_script} does not load the database owner helper"
+  grep -Fq "ensure_database_owner_label \"\$STACK_NAME\"" "${TEST_SCRIPT_DIR}/${deploy_script}" ||
+    fail "${deploy_script} does not bootstrap the database owner"
+done
 
 printf 'database owner deployment helper tests passed\n'

--- a/scripts/tests/database-owner-test.sh
+++ b/scripts/tests/database-owner-test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+TEST_DIR="$(mktemp -d)"
+readonly TEST_DIR
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly TEST_SCRIPT_DIR
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# shellcheck source=scripts/lib/database-owner.sh
+source "${TEST_SCRIPT_DIR}/lib/database-owner.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+mock_bin="${TEST_DIR}/bin"
+mock_log="${TEST_DIR}/docker.log"
+mkdir -p "$mock_bin"
+
+cat > "${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [ "${1:-}" = "node" ] && [ "${2:-}" = "ls" ]; then
+  case "${*:3}" in
+    *databases.enabled=true*) printf '%s\n' "${MOCK_DATABASE_NODES:-}" ;;
+    *postgres.enabled=true*) printf '%s\n' "${MOCK_POSTGRES_NODES:-}" ;;
+  esac
+  exit 0
+fi
+if [ "${1:-}" = "service" ] && [ "${2:-}" = "inspect" ]; then
+  [ "${MOCK_SERVICE_EXISTS:-false}" = "true" ]
+  exit
+fi
+if [ "${1:-}" = "service" ] && [ "${2:-}" = "ps" ]; then
+  printf '%s\n' "${MOCK_SERVICE_NODE:-}"
+  exit 0
+fi
+if [ "${1:-}" = "node" ] && [ "${2:-}" = "update" ]; then
+  printf '%s\n' "$*" >> "${MOCK_DOCKER_LOG}"
+  exit 0
+fi
+
+printf 'unexpected docker command: %s\n' "$*" >&2
+exit 1
+EOF
+chmod 700 "${mock_bin}/docker"
+
+PATH="${mock_bin}:${PATH}" \
+MOCK_DOCKER_LOG="$mock_log" \
+MOCK_SERVICE_EXISTS=true \
+MOCK_SERVICE_NODE="existing-owner" \
+ensure_database_owner_label "test-stack"
+grep -q 'databases.enabled=true existing-owner' "$mock_log" || fail "existing service owner was not labeled"
+
+: > "$mock_log"
+PATH="${mock_bin}:${PATH}" \
+MOCK_DOCKER_LOG="$mock_log" \
+MOCK_POSTGRES_NODES="fresh-owner" \
+ensure_database_owner_label "test-stack"
+grep -q 'databases.enabled=true fresh-owner' "$mock_log" || fail "fresh install did not use the PostgreSQL owner"
+
+if PATH="${mock_bin}:${PATH}" \
+  MOCK_DOCKER_LOG="$mock_log" \
+  MOCK_DATABASE_NODES=$'owner-one\nowner-two' \
+  ensure_database_owner_label "test-stack"; then
+  fail "multiple database owners were accepted"
+fi
+
+printf 'database owner deployment helper tests passed\n'

--- a/tools/deployment-preflight/project.json
+++ b/tools/deployment-preflight/project.json
@@ -11,6 +11,7 @@
         "{workspaceRoot}/docker-compose*.yml",
         "{workspaceRoot}/scripts/merge-compose-files.sh",
         "{workspaceRoot}/scripts/deploy-swarm.sh",
+        "{workspaceRoot}/scripts/force-deploy.sh",
         "{workspaceRoot}/scripts/lib/database-owner.sh",
         "{workspaceRoot}/scripts/tests/database-owner-test.sh"
       ],
@@ -18,7 +19,8 @@
         "cwd": "{workspaceRoot}",
         "commands": [
           "bash tools/deployment-preflight/validate-compose.sh all",
-          "shellcheck scripts/deploy-swarm.sh scripts/lib/database-owner.sh scripts/tests/database-owner-test.sh",
+          "bash -n scripts/deploy-swarm.sh scripts/force-deploy.sh",
+          "shellcheck scripts/lib/database-owner.sh scripts/tests/database-owner-test.sh",
           "bash scripts/tests/database-owner-test.sh"
         ],
         "parallel": false

--- a/tools/deployment-preflight/project.json
+++ b/tools/deployment-preflight/project.json
@@ -9,11 +9,19 @@
       "inputs": [
         "{projectRoot}/**/*",
         "{workspaceRoot}/docker-compose*.yml",
-        "{workspaceRoot}/scripts/merge-compose-files.sh"
+        "{workspaceRoot}/scripts/merge-compose-files.sh",
+        "{workspaceRoot}/scripts/deploy-swarm.sh",
+        "{workspaceRoot}/scripts/lib/database-owner.sh",
+        "{workspaceRoot}/scripts/tests/database-owner-test.sh"
       ],
       "options": {
         "cwd": "{workspaceRoot}",
-        "command": "tools/deployment-preflight/validate-compose.sh all"
+        "commands": [
+          "bash tools/deployment-preflight/validate-compose.sh all",
+          "shellcheck scripts/deploy-swarm.sh scripts/lib/database-owner.sh scripts/tests/database-owner-test.sh",
+          "bash scripts/tests/database-owner-test.sh"
+        ],
+        "parallel": false
       }
     },
     "test-compose": {

--- a/tools/deployment-preflight/validate-compose.sh
+++ b/tools/deployment-preflight/validate-compose.sh
@@ -78,7 +78,7 @@ validate_swarm_config() {
     vps-service
   )
 
-  validate_compose_file docker-compose.swarm.yml "${core_services[@]}"
+  validate_compose_file docker-compose.swarm.yml "${core_services[@]}" databases-service databases-proxy
   validate_compose_file docker-compose.swarm.dev.yml "${core_services[@]}"
   validate_compose_file docker-compose.swarm.ha.yml \
     etcd \


### PR DESCRIPTION
## Summary

- record the Docker node identity and database location when provisioning managed databases
- reconcile existing database containers onto their actual host node during route loading
- populate node metadata with Docker's node address and region label
- prefer exact resource locations in DNS and reject ambiguous cross-region fallbacks

## Root cause

Managed database records did not persist their owning node, while Swarm node metadata omitted the node IP. In a multi-region `NODE_IPS` configuration, DNS therefore fell back to whichever region happened to be encountered first. A database could consequently resolve to a host that did not expose its proxy port.

The same arbitrary fallback was shared by deployment and game-server routing when their node metadata was incomplete.

## Impact

New and existing managed databases resolve to the node that owns their container. Deployment and game-server resolution also benefits from populated node IP metadata, and incomplete multi-region records now fail safely instead of returning an unrelated host.

## Validation

- `cd apps/shared && go test ./... -count=1`
- `cd apps/databases-service && go test ./... -count=1`
- `cd apps/dns-service && go test ./... -count=1`
- `cd apps/orchestrator-service && go test ./... -count=1`
- `git diff --check`
