### PR TITLE
fix(tls): use lego v5 container layout

### DIFF
--- a/scripts/manage-preview-tls.sh
+++ b/scripts/manage-preview-tls.sh
@@ -11,6 +11,7 @@ readonly DEFAULT_STATE_DIR="/var/lib/obiente/preview-tls"
 readonly DEFAULT_RENEW_DAYS="30"
 readonly DEFAULT_STACK_NAME="obiente"
 readonly CERTIFICATE_NAME="preview-wildcard"
+readonly LEGO_CONTAINER_STATE_DIR="/var/lib/lego"
 
 log() {
   printf '%s\n' "$*"
@@ -487,17 +488,13 @@ run_lego() {
   local ca_server="$8"
   local force_renewal="$9"
   local lego_command="${10}"
-  local effective_renew_days="$renew_days"
   local -a lego_args=()
   local -a security_args=(--security-opt no-new-privileges:true)
 
-  if [ "$force_renewal" = "true" ]; then
-    effective_renew_days=36500
-  fi
-
   lego_args=(
     --log.format text
-    --path /lego
+    run
+    --path "$LEGO_CONTAINER_STATE_DIR"
     --cert.name "$CERTIFICATE_NAME"
     --email "$email"
     --accept-tos
@@ -506,11 +503,13 @@ run_lego() {
     --domains "*.$domain"
   )
   [ -z "$ca_server" ] || lego_args+=(--server "$ca_server")
-  lego_args+=("$lego_command")
   if [ "$lego_command" = "renew" ]; then
-    lego_args+=(--days "$effective_renew_days")
+    lego_args+=(--renew-days "$renew_days")
   else
     lego_args+=(--force-cert-domains)
+  fi
+  if [ "$force_renewal" = "true" ]; then
+    lego_args+=(--renew-force)
   fi
 
   if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null || true)" != "Disabled" ]; then
@@ -524,7 +523,7 @@ run_lego() {
     --tmpfs /tmp:rw,noexec,nosuid,size=16m \
     --cap-drop ALL \
     "${security_args[@]}" \
-    --mount "type=bind,src=${state_dir},dst=/lego" \
+    --mount "type=bind,src=${state_dir},dst=${LEGO_CONTAINER_STATE_DIR}" \
     --env-file "$credentials_file" \
     "$image" "${lego_args[@]}"
 }

--- a/scripts/tests/manage-preview-tls-test.sh
+++ b/scripts/tests/manage-preview-tls-test.sh
@@ -215,8 +215,10 @@ MOCK_DOCKER_ARGS_FILE="$mock_docker_args" \
   --no-activate \
   >/dev/null
 
-grep -q -- "goacme/lego:v5.2.1.* run --force-cert-domains" "$mock_docker_args" || fail "lego run command/options were ordered incorrectly"
+grep -q -- "goacme/lego:v5.2.1 --log.format text run --path /var/lib/lego.*--force-cert-domains" "$mock_docker_args" || fail "lego v5 run command/options were ordered incorrectly"
 grep -q -- "--env-file $mock_credentials goacme/lego:v5.2.1" "$mock_docker_args" || fail "provider credentials were not passed as a Docker run option"
+grep -q -- "--mount type=bind,src=$mock_state,dst=/var/lib/lego" "$mock_docker_args" || fail "lego state was not mounted away from the /lego executable"
+grep -q -- "--path /var/lib/lego" "$mock_docker_args" || fail "lego did not use the mounted state directory"
 
 selected_certificate_secret="$(sed -n 's/^PREVIEW_TLS_CERT_SECRET=//p' "$mock_env")"
 selected_key_secret="$(sed -n 's/^PREVIEW_TLS_KEY_SECRET=//p' "$mock_env")"
@@ -239,7 +241,7 @@ MOCK_DOCKER_ARGS_FILE="$mock_docker_args" \
   >/dev/null
 
 assert_equals "$secret_count_before" "$(find "$mock_secrets" -type f | wc -l)" "unchanged renewal created duplicate secrets"
-grep -q -- "goacme/lego:v5.2.1.* renew --days " "$mock_docker_args" || fail "scheduled renewal did not use lego renew with its threshold"
+grep -q -- "goacme/lego:v5.2.1 --log.format text run .*--renew-days 30" "$mock_docker_args" || fail "scheduled renewal did not use the lego v5 renewal threshold"
 
 issue_only_state="${TEST_DIR}/issue-only-state"
 issue_only_secrets="${TEST_DIR}/issue-only-secrets"
@@ -262,7 +264,7 @@ MOCK_DOCKER_ARGS_FILE="$mock_docker_args" \
   >/dev/null
 assert_equals "0" "$(find "$issue_only_secrets" -type f | wc -l)" "issue-only mode created Swarm secrets"
 assert_equals $'DOMAIN=obiente.cloud\nENABLE_DNS=false' "$(cat "$issue_only_env")" "issue-only mode changed the environment file"
-grep -q -- 'goacme/lego:v5.2.1.* run --force-cert-domains' "$mock_docker_args" || fail "issue-only mode did not force a fresh DNS challenge"
+grep -q -- 'goacme/lego:v5.2.1 --log.format text run .*--force-cert-domains.*--renew-force' "$mock_docker_args" || fail "issue-only mode did not force a fresh DNS challenge"
 
 assert_fails "staging activation was accepted" env \
   PATH="${mock_bin}:${PATH}" \


### PR DESCRIPTION
## Summary

- mount persistent certificate state at /var/lib/lego instead of over the image executable at /lego
- place lego v5 certificate options after the run subcommand
- use the v5 renewal flags while preserving forced issuance behavior
- assert the mount target and command layout in the preview TLS regression test

## Validation

- bash scripts/tests/manage-preview-tls-test.sh
- bash -n scripts/manage-preview-tls.sh scripts/tests/manage-preview-tls-test.sh
- goacme/lego:v5.2.1 container smoke tests for setup and forced-renewal argument layouts

No DNS provider credentials or live infrastructure values were used.