### PR TITLE
fix(tls): isolate preview ACME account

### DIFF
--- a/scripts/manage-preview-tls.sh
+++ b/scripts/manage-preview-tls.sh
@@ -11,6 +11,7 @@ readonly DEFAULT_STATE_DIR="/var/lib/obiente/preview-tls"
 readonly DEFAULT_RENEW_DAYS="30"
 readonly DEFAULT_STACK_NAME="obiente"
 readonly CERTIFICATE_NAME="preview-wildcard"
+readonly LEGO_ACCOUNT_ID="preview-tls"
 readonly LEGO_CONTAINER_STATE_DIR="/var/lib/lego"
 
 log() {
@@ -495,6 +496,7 @@ run_lego() {
     --log.format text
     run
     --path "$LEGO_CONTAINER_STATE_DIR"
+    --account-id "$LEGO_ACCOUNT_ID"
     --cert.name "$CERTIFICATE_NAME"
     --email "$email"
     --accept-tos

--- a/scripts/tests/manage-preview-tls-test.sh
+++ b/scripts/tests/manage-preview-tls-test.sh
@@ -215,7 +215,7 @@ MOCK_DOCKER_ARGS_FILE="$mock_docker_args" \
   --no-activate \
   >/dev/null
 
-grep -q -- "goacme/lego:v5.2.1 --log.format text run --path /var/lib/lego.*--force-cert-domains" "$mock_docker_args" || fail "lego v5 run command/options were ordered incorrectly"
+grep -q -- "goacme/lego:v5.2.1 --log.format text run --path /var/lib/lego --account-id preview-tls.*--force-cert-domains" "$mock_docker_args" || fail "lego v5 run command/options were ordered incorrectly"
 grep -q -- "--env-file $mock_credentials goacme/lego:v5.2.1" "$mock_docker_args" || fail "provider credentials were not passed as a Docker run option"
 grep -q -- "--mount type=bind,src=$mock_state,dst=/var/lib/lego" "$mock_docker_args" || fail "lego state was not mounted away from the /lego executable"
 grep -q -- "--path /var/lib/lego" "$mock_docker_args" || fail "lego did not use the mounted state directory"


### PR DESCRIPTION
## Summary

- use a dedicated stable lego account ID for preview certificate automation
- bypass an incomplete default-email account record without deleting its key or state
- assert the account selection in the preview TLS regression test

## Validation

- bash scripts/tests/manage-preview-tls-test.sh
- bash -n scripts/manage-preview-tls.sh scripts/tests/manage-preview-tls-test.sh
- goacme/lego:v5.2.1 container argument smoke test

No DNS provider credentials or live infrastructure values were used.